### PR TITLE
Migrate from deprecated github to octokit library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ resources/dist/
 *.iml
 jbe-build-wrapper.xml
 deployment-properties.ini
+*.swp

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,21 @@
                 "@fortawesome/fontawesome-common-types": "0.1.3"
             }
         },
+        "@octokit/rest": {
+            "version": "15.2.6",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.2.6.tgz",
+            "integrity": "sha512-KcqG0zjnjzUqn7wczz/fKiueNpTLiAI7erhUG6bXWAsYKJJlqnwYonFSXrMW/nmes5y+qOk4uSyHBh1mdRXdVQ==",
+            "requires": {
+                "before-after-hook": "1.1.0",
+                "btoa-lite": "1.0.0",
+                "debug": "3.1.0",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lodash": "4.17.5",
+                "node-fetch": "2.1.2",
+                "url-template": "2.0.8"
+            }
+        },
         "acorn": {
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
@@ -257,6 +272,11 @@
                 "tweetnacl": "0.14.5"
             }
         },
+        "before-after-hook": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+            "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+        },
         "big.js": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -419,6 +439,11 @@
             "requires": {
                 "pako": "1.0.6"
             }
+        },
+        "btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
         },
         "buffer": {
             "version": "5.1.0",
@@ -939,11 +964,6 @@
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
             "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true
-        },
-        "dotenv": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-            "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
         },
         "duplexify": {
             "version": "3.5.4",
@@ -2397,20 +2417,6 @@
                 "assert-plus": "1.0.0"
             }
         },
-        "github": {
-            "version": "13.1.1",
-            "resolved": "https://registry.npmjs.org/github/-/github-13.1.1.tgz",
-            "integrity": "sha512-BpItPaOCuvotnNUGXSSEDkB86eqQ7+k7j8/+lu5gbRmNnFPW/uQyFezH1fjy7XojieVNzD/+MgPhBngaw+Ocfw==",
-            "requires": {
-                "debug": "3.1.0",
-                "dotenv": "4.0.0",
-                "https-proxy-agent": "2.2.1",
-                "is-stream": "1.1.0",
-                "lodash": "4.17.5",
-                "proxy-from-env": "1.0.0",
-                "url-template": "2.0.8"
-            }
-        },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -2574,6 +2580,15 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
             "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
             "dev": true
+        },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "requires": {
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
+            }
         },
         "http-signature": {
             "version": "1.2.0",
@@ -2807,7 +2822,8 @@
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -3267,6 +3283,11 @@
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
+        "node-fetch": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+            "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        },
         "node-gitlab-api": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/node-gitlab-api/-/node-gitlab-api-2.2.8.tgz",
@@ -3661,11 +3682,6 @@
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
-        },
-        "proxy-from-env": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
         },
         "prr": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "dependencies": {
         "@fortawesome/fontawesome": "^1.1.3",
         "@fortawesome/fontawesome-free-solid": "^5.0.6",
+        "@octokit/rest": "^15.2.6",
         "base64-js": "^1.2.1",
         "buffer": "^5.0.7",
-        "github": "^13.0.1",
         "gzip-js": "^0.3.2",
         "node-gitlab-api": "^2.2.3"
     },

--- a/src/RtcGitConnectorModules.js
+++ b/src/RtcGitConnectorModules.js
@@ -40,7 +40,7 @@ export function encoder () {
 }
 
 // GitHub API client library
-export const GitHubApi = require('github');
+export const GitHubApi = require('@octokit/rest');
 
 // GitLab API client library
 export const GitLabApi = require('node-gitlab-api');


### PR DESCRIPTION
The github npm library has been renamed to @octokit/rest. Changed dependencies and imports.