### PR TITLE
Basic refactoring of the view renderers

### DIFF
--- a/resources/ui/widget/css/RtcGitConnector.css
+++ b/resources/ui/widget/css/RtcGitConnector.css
@@ -80,7 +80,6 @@
 
 .rtcGitConnectorSelectLinkType {
     display: flex;
-    background-color: gray;
 }
 
 .rtcGitConnectorSelectLinkType .linkTypeItem {
@@ -91,7 +90,7 @@
     font-weight: bold;
     cursor: pointer;
     background-color: white;
-    margin: 1px;
+    border: 1px solid gray;
 }
 
 .rtcGitConnectorSelectLinkType .linkTypeItem:hover {

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -295,41 +295,17 @@ define([
                     innerHTML: "Select a commit to view more details"
                 }, commitDetailsNode);
             } else {
-                this.addToDetailsViewNode(commitDetailsNode, "Message: ", commit.message.replace(/(\r\n|\n|\r)/gm, "<br />"));
-                this.addToDetailsViewNode(commitDetailsNode, "Author: ", commit.authorName + " (" + commit.authorEmail + ")");
-                this.addToDetailsViewNode(commitDetailsNode, "Date: ", new Date(commit.authoredDate).toString());
-                this.addToDetailsViewNode(commitDetailsNode, "SHA: ", commit.sha);
+                ViewHelper.AddToDetailsViewNode(commitDetailsNode, "Message: ", commit.message.replace(/(\r\n|\n|\r)/gm, "<br />"));
+                ViewHelper.AddToDetailsViewNode(commitDetailsNode, "Author: ", commit.authorName + " (" + commit.authorEmail + ")");
+                ViewHelper.AddToDetailsViewNode(commitDetailsNode, "Date: ", new Date(commit.authoredDate).toString());
+                ViewHelper.AddToDetailsViewNode(commitDetailsNode, "SHA: ", commit.sha);
                 var linkNode = domConstruct.create("a", {
                     innerHTML: "Open this commit in a new tab",
                     href: commit.webUrl,
                     target: "_blank"
                 });
-                this.addLinkToDetailsViewNode(commitDetailsNode, "Web Link: ", linkNode);
+                ViewHelper.AddLinkToDetailsViewNode(commitDetailsNode, "Web Link: ", linkNode);
             }
-        },
-
-        addToDetailsViewNode: function (detailsViewNode, label, value) {
-            var commitMessageNode = this.createDetailsViewSpan(detailsViewNode, label);
-            domConstruct.create("span", {
-                innerHTML: value
-            }, commitMessageNode);
-        },
-
-        addLinkToDetailsViewNode: function (detailsViewNode, label, linkNode) {
-            var commitMessageNode = this.createDetailsViewSpan(detailsViewNode, label);
-            domConstruct.place(linkNode, commitMessageNode);
-        },
-
-        createDetailsViewSpan: function (detailsViewNode, label) {
-            var commitMessageNode = domConstruct.create("span", {
-                "class": "rtcGitConnectorViewAndSelectDetailsSpan"
-            }, detailsViewNode);
-            domConstruct.create("span", {
-                "class": "rtcGitConnectorViewAndSelectDetailsLabel",
-                innerHTML: label
-            }, commitMessageNode);
-
-            return commitMessageNode;
         },
 
         // Sort the view commits by the authoredDate

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -377,20 +377,9 @@ define([
         _highlightFilterText: function (filterText, filterBy, filterResult) {
             for (var i=0; i < filterResult.length; i++) {
                 for (var j=0; j < filterBy.length; j++) {
-                    filterResult[i][filterBy[j]] = this._highlightTextInString(filterText, filterResult[i][filterBy[j]]);
+                    filterResult[i][filterBy[j]] = ViewHelper.HighlightTextInString(filterText, filterResult[i][filterBy[j]]);
                 }
             }
-        },
-
-        _highlightTextInString: function (searchText, fullText) {
-            var startIndex;
-            if (searchText.toLowerCase() && (startIndex = fullText.toLowerCase().indexOf(searchText)) > -1) {
-                var beforeFound = fullText.slice(0, startIndex);
-                var found = fullText.slice(startIndex, startIndex + searchText.length);
-                var afterFound = this._highlightTextInString(searchText, fullText.slice(startIndex + searchText.length));
-                fullText = beforeFound + "<b class='rtcGitConnectorHighlightText'>" + found + "</b>" + afterFound;
-            }
-            return fullText;
         },
 
         // Checks if the node or any of it's parents have the class name

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -27,16 +27,11 @@ define([
         jazzRestService: null,
         gitRestService: null,
         viewCommits: null,
-        fontAwesome: null,
 
         constructor: function () {
             this.mainDataStore = MainDataStore.getInstance();
             this.jazzRestService = JazzRestService.getInstance();
             this.gitRestService = GitRestService.getInstance();
-
-            if (typeof com_siemens_bt_jazz_rtcgitconnector_modules !== 'undefined') {
-                this.fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
-            }
         },
 
         startup: function () {
@@ -221,42 +216,30 @@ define([
                     }
                 });
 
-                if (commit.alreadyLinked) {
-                    var check = self.fontAwesome.icon({prefix: 'fas', iconName: 'check'});
-                    domClass.add(commitListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton emptyButton",
-                        innerHTML: check.html[0]
-                    }, commitListItem);
-                } else {
-                    var link = self.fontAwesome.icon({prefix: 'fas', iconName: 'link'});
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton",
-                        innerHTML: link.html[0]
-                    }, commitListItem);
-                }
-
-                var commitListItemContent = domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemContent"
-                }, commitListItem);
-
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine",
-                    innerHTML: commit.message.split(/\r?\n/g)[0]
-                }, commitListItemContent);
+                var firstLine = commit.message.split(/\r?\n/g)[0];
+                var secondLine;
+                var buttonName = "";
+                var iconName;
 
                 if (commit.authoredDate) {
                     var commitDate = new Date(commit.authoredDate);
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: commit.authorName + " committed on " + commitDate.toDateString() + " at " + ("00" + commitDate.getHours()).slice(-2) + ":" + ("00" + commitDate.getMinutes()).slice(-2)
-                    }, commitListItemContent);
+                    secondLine = commit.authorName + " committed on "
+                        + commitDate.toDateString() + " at "
+                        + ("00" + commitDate.getHours()).slice(-2) + ":"
+                        + ("00" + commitDate.getMinutes()).slice(-2);
                 } else {
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "&nbsp;"
-                    }, commitListItemContent);
+                    secondLine = "&nbsp;";
                 }
+
+                if (commit.alreadyLinked) {
+                    domClass.add(commitListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");
+                    buttonName = "emptyButton";
+                    iconName = "check";
+                } else {
+                    iconName = "link";
+                }
+                
+                ViewHelper.DrawListItem(commitListItem, firstLine, secondLine, buttonName, iconName);
             });
         },
 

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -217,19 +217,9 @@ define([
                 });
 
                 var firstLine = commit.message.split(/\r?\n/g)[0];
-                var secondLine;
+                var secondLine = ViewHelper.GetCommitDateString(commit);
                 var buttonName = "";
                 var iconName;
-
-                if (commit.authoredDate) {
-                    var commitDate = new Date(commit.authoredDate);
-                    secondLine = commit.authorName + " committed on "
-                        + commitDate.toDateString() + " at "
-                        + ("00" + commitDate.getHours()).slice(-2) + ":"
-                        + ("00" + commitDate.getMinutes()).slice(-2);
-                } else {
-                    secondLine = "&nbsp;";
-                }
 
                 if (commit.alreadyLinked) {
                     domClass.add(commitListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");
@@ -238,7 +228,7 @@ define([
                 } else {
                     iconName = "link";
                 }
-                
+
                 ViewHelper.DrawListItem(commitListItem, firstLine, secondLine, buttonName, iconName);
             });
         },

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -369,15 +369,7 @@ define([
                     commit.authorName.toLowerCase().indexOf(filterText) > -1 ||
                     commit.authorEmail.toLowerCase().indexOf(filterText) > -1;
             });
-            this._highlightFilterText(filterText, ["sha", "message", "authorName", "authorEmail"], this.viewCommits);
-        },
-
-        _highlightFilterText: function (filterText, filterBy, filterResult) {
-            for (var i=0; i < filterResult.length; i++) {
-                for (var j=0; j < filterBy.length; j++) {
-                    filterResult[i][filterBy[j]] = ViewHelper.HighlightTextInString(filterText, filterResult[i][filterBy[j]]);
-                }
-            }
+            ViewHelper.HighlightFilterText(filterText, ["sha", "message", "authorName", "authorEmail"], this.viewCommits);
         },
 
         // Checks if the node or any of it's parents have the class name

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -37,8 +37,6 @@ define([
             if (typeof com_siemens_bt_jazz_rtcgitconnector_modules !== 'undefined') {
                 this.fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
             }
-
-            ViewHelper.TestFunction("test from other file");
         },
 
         startup: function () {

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -10,12 +10,13 @@ define([
     "./DataStores/MainDataStore",
     "./RestServices/JazzRestService",
     "./RestServices/GitRestService",
+    "./ViewHelper",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewAndSelectCommits.html"
 ], function (declare, array, lang, dom, domClass, domConstruct, on, query,
-    MainDataStore, JazzRestService, GitRestService,
+    MainDataStore, JazzRestService, GitRestService, ViewHelper,
     _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectCommits",
@@ -36,6 +37,8 @@ define([
             if (typeof com_siemens_bt_jazz_rtcgitconnector_modules !== 'undefined') {
                 this.fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
             }
+
+            ViewHelper.TestFunction("test from other file");
         },
 
         startup: function () {

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -197,7 +197,7 @@ define([
                 on(commitListItem, "click", function (event) {
                     var commitSha = this.getAttribute("data-commit-sha");
 
-                    if (!commit.alreadyLinked && self.isNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
+                    if (!commit.alreadyLinked && ViewHelper.IsNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
                         // Remove the commit with the specified sha from the commits list in store and add to the selected list
                         if (commitSha) {
                             var selectedCommit = null;
@@ -370,19 +370,6 @@ define([
                     commit.authorEmail.toLowerCase().indexOf(filterText) > -1;
             });
             ViewHelper.HighlightFilterText(filterText, ["sha", "message", "authorName", "authorEmail"], this.viewCommits);
-        },
-
-        // Checks if the node or any of it's parents have the class name
-        isNodeInClass: function (node, className) {
-            if (node.classList && node.classList.contains(className)) {
-                return true;
-            }
-
-            if (node.parentNode) {
-                return this.isNodeInClass(node.parentNode, className);
-            }
-
-            return false;
         }
     });
 });

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -334,28 +334,7 @@ define([
 
         // Sort the view commits by the authoredDate
         sortViewCommitsByDate: function () {
-            var self = this;
-
-            // Create a temp array so that the date objects are only created once
-            var tempArray = this.viewCommits.map(function (el, i) {
-                return {
-                    index: i,
-                    value: new Date(el.authoredDate).getTime()
-                };
-            });
-
-            // Sort the temp array
-            tempArray.sort(function (a, b) {
-                return b.value - a.value;
-            });
-
-            // Get a sorted version of the original array
-            var sortedArray = tempArray.map(function (el) {
-                return self.viewCommits[el.index];
-            });
-
-            // Use the sorted array
-            this.viewCommits = sortedArray;
+            this.viewCommits = ViewHelper.SortListDataByDate("authoredDate", this.viewCommits);
         },
 
         // Filter the view commits using the filter text.

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -362,7 +362,9 @@ define([
         // Only keep commits that contain the filter text either
         // in the commit message or commit author name or sha or email
         filterViewCommitsByText: function (filterText) {
-            this.viewCommits = ViewHelper.FilterListDataByText(filterText, ["sha", "message", "authorName", "authorEmail"], this.viewCommits);
+            this.viewCommits = ViewHelper.FilterListDataByText(filterText,
+                ["sha", "message", "authorName", "authorEmail"],
+                this.viewCommits);
         }
     });
 });

--- a/resources/ui/widget/js/ViewAndSelectCommits.js
+++ b/resources/ui/widget/js/ViewAndSelectCommits.js
@@ -362,14 +362,7 @@ define([
         // Only keep commits that contain the filter text either
         // in the commit message or commit author name or sha or email
         filterViewCommitsByText: function (filterText) {
-            filterText = filterText.toLowerCase();
-            this.viewCommits = this.viewCommits.filter(function (commit) {
-                return commit.sha.toLowerCase().indexOf(filterText) > -1 ||
-                    commit.message.toLowerCase().indexOf(filterText) > -1 ||
-                    commit.authorName.toLowerCase().indexOf(filterText) > -1 ||
-                    commit.authorEmail.toLowerCase().indexOf(filterText) > -1;
-            });
-            ViewHelper.HighlightFilterText(filterText, ["sha", "message", "authorName", "authorEmail"], this.viewCommits);
+            this.viewCommits = ViewHelper.FilterListDataByText(filterText, ["sha", "message", "authorName", "authorEmail"], this.viewCommits);
         }
     });
 });

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -380,36 +380,11 @@ define([
 
         // Filter the view issues using the filter text.
         // Only keep issues that contain the filter text either
-        // in the issue title or issue author name or id or email
+        // in the issue title or issue author name or id or state
         filterViewIssuesByText: function (filterText) {
-            filterText = filterText.toLowerCase();
-            this.viewIssues = this.viewIssues.filter(function (issue) {
-                issue.id = issue.id.toString();
-                return issue.id.toLowerCase().indexOf(filterText) > -1 ||
-                    issue.title.toLowerCase().indexOf(filterText) > -1 ||
-                    issue.state.toLowerCase().indexOf(filterText) > -1 ||
-                    issue.openedBy.toLowerCase().indexOf(filterText) > -1;
-            });
-            this._highlightFilterText(filterText, ["id", "title", "state", "openedBy"], this.viewIssues);
-        },
-
-        _highlightFilterText: function (filterText, filterBy, filterResult) {
-            for (var i=0; i < filterResult.length; i++) {
-                for (var j=0; j < filterBy.length; j++) {
-                    filterResult[i][filterBy[j]] = this._highlightTextInString(filterText, filterResult[i][filterBy[j]]);
-                }
-            }
-        },
-
-        _highlightTextInString: function (searchText, fullText) {
-            var startIndex;
-            if (searchText.toLowerCase() && (startIndex = fullText.toLowerCase().indexOf(searchText)) > -1) {
-                var beforeFound = fullText.slice(0, startIndex);
-                var found = fullText.slice(startIndex, startIndex + searchText.length);
-                var afterFound = this._highlightTextInString(searchText, fullText.slice(startIndex + searchText.length));
-                fullText = beforeFound + "<b class='rtcGitConnectorHighlightText'>" + found + "</b>" + afterFound;
-            }
-            return fullText;
+            this.viewIssues = ViewHelper.FilterListDataByText(filterText,
+                ["id", "title", "state", "openedBy"],
+                this.viewIssues);
         }
     });
 });

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -314,42 +314,18 @@ define([
                         "The new issue will also be added as a link."
                 }, issueDetailsNode);
             } else {
-                this.addToDetailsViewNode(issueDetailsNode, "Title: ", issue.title);
-                this.addToDetailsViewNode(issueDetailsNode, "State: ", issue.state);
-                this.addToDetailsViewNode(issueDetailsNode, "Opened by: ", issue.openedBy);
-                this.addToDetailsViewNode(issueDetailsNode, "Date opened: ", new Date(issue.openedDate).toString());
-                this.addToDetailsViewNode(issueDetailsNode, "Issue id: ", "#" + issue.id);
+                ViewHelper.AddToDetailsViewNode(issueDetailsNode, "Title: ", issue.title);
+                ViewHelper.AddToDetailsViewNode(issueDetailsNode, "State: ", issue.state);
+                ViewHelper.AddToDetailsViewNode(issueDetailsNode, "Opened by: ", issue.openedBy);
+                ViewHelper.AddToDetailsViewNode(issueDetailsNode, "Date opened: ", new Date(issue.openedDate).toString());
+                ViewHelper.AddToDetailsViewNode(issueDetailsNode, "Issue id: ", "#" + issue.id);
                 var linkNode = domConstruct.create("a", {
                     innerHTML: "Open this issue in a new tab",
                     href: issue.webUrl,
                     target: "_blank"
                 });
-                this.addLinkToDetailsViewNode(issueDetailsNode, "Web Link: ", linkNode);
+                ViewHelper.AddLinkToDetailsViewNode(issueDetailsNode, "Web Link: ", linkNode);
             }
-        },
-
-        addToDetailsViewNode: function (detailsViewNode, label, value) {
-            var issueTitleNode = this.createDetailsViewSpan(detailsViewNode, label);
-            domConstruct.create("span", {
-                innerHTML: value
-            }, issueTitleNode);
-        },
-
-        addLinkToDetailsViewNode: function (detailsViewNode, label, linkNode) {
-            var issueTitleNode = this.createDetailsViewSpan(detailsViewNode, label);
-            domConstruct.place(linkNode, issueTitleNode);
-        },
-
-        createDetailsViewSpan: function (detailsViewNode, label) {
-            var issueTitleNode = domConstruct.create("span", {
-                "class": "rtcGitConnectorViewAndSelectDetailsSpan"
-            }, detailsViewNode);
-            domConstruct.create("span", {
-                "class": "rtcGitConnectorViewAndSelectDetailsLabel",
-                innerHTML: label
-            }, issueTitleNode);
-
-            return issueTitleNode;
         },
 
         // Sort the view issues by the openedDate

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -198,7 +198,7 @@ define([
                 on(issueListItem, "click", function (event) {
                     var issueId = this.getAttribute("data-issue-id");
 
-                    if (!issue.alreadyLinked && self.isNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
+                    if (!issue.alreadyLinked && ViewHelper.IsNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
                         // Remove the issue with the specified id from the issues list in store and add to the selected list
                         if (issueId) {
                             var selectedIssue = null;
@@ -410,19 +410,6 @@ define([
                 fullText = beforeFound + "<b class='rtcGitConnectorHighlightText'>" + found + "</b>" + afterFound;
             }
             return fullText;
-        },
-
-        // Checks if the node or any of it's parents have the class name
-        isNodeInClass: function (node, className) {
-            if (node.classList && node.classList.contains(className)) {
-                return true;
-            }
-
-            if (node.parentNode) {
-                return this.isNodeInClass(node.parentNode, className);
-            }
-
-            return false;
         }
     });
 });

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -227,15 +227,7 @@ define([
                     buttonName = "addButton";
                     iconName = "plus";
                 } else {
-                    if (issue.openedDate) {
-                        var issueDate = new Date(issue.openedDate);
-                        secondLine = "#" + issue.id + " opened by " + issue.openedBy +
-                            " on " + issueDate.toDateString() +
-                            " at " + ("00" + issueDate.getHours()).slice(-2) +
-                            ":" + ("00" + issueDate.getMinutes()).slice(-2);
-                    } else {
-                        secondLine = "&nbsp;";
-                    }
+                    secondLine = ViewHelper.GetIssueOrRequestDateString(issue);
 
                     if (issue.alreadyLinked) {
                         domClass.add(issueListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -27,16 +27,11 @@ define([
         jazzRestService: null,
         gitRestService: null,
         viewIssues: null,
-        fontAwesome: null,
 
         constructor: function () {
             this.mainDataStore = MainDataStore.getInstance();
             this.jazzRestService = JazzRestService.getInstance();
             this.gitRestService = GitRestService.getInstance();
-
-            if (typeof com_siemens_bt_jazz_rtcgitconnector_modules !== 'undefined') {
-                this.fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
-            }
         },
 
         startup: function () {
@@ -222,53 +217,36 @@ define([
                     }
                 });
 
-                if (issue.id < 0) {
-                    var plus = self.fontAwesome.icon({prefix: 'fas', iconName: 'plus'});
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton addButton",
-                        innerHTML: plus.html[0]
-                    }, issueListItem);
-                } else if (issue.alreadyLinked) {
-                    var check = self.fontAwesome.icon({prefix: 'fas', iconName: 'check'});
-                    domClass.add(issueListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton emptyButton",
-                        innerHTML: check.html[0]
-                    }, issueListItem);
-                } else {
-                    var link = self.fontAwesome.icon({prefix: 'fas', iconName: 'link'});
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton",
-                        innerHTML: link.html[0]
-                    }, issueListItem);
-                }
-
-                var issueListItemContent = domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemContent"
-                }, issueListItem);
-
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine",
-                    innerHTML: issue.title
-                }, issueListItemContent);
+                var firstLine = issue.title;
+                var secondLine;
+                var buttonName = "";
+                var iconName;
 
                 if (issue.id < 0) {
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "This will create a new issue in " + gitHost + " using the information from the current work item"
-                    }, issueListItemContent);
-                } else if (issue.openedDate) {
-                    var issueDate = new Date(issue.openedDate);
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "#" + issue.id + " opened by " + issue.openedBy + " on " + issueDate.toDateString() + " at " + ("00" + issueDate.getHours()).slice(-2) + ":" + ("00" + issueDate.getMinutes()).slice(-2)
-                    }, issueListItemContent);
+                    secondLine = "This will create a new issue in " + gitHost + " using the information from the current work item";
+                    buttonName = "addButton";
+                    iconName = "plus";
                 } else {
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "&nbsp;"
-                    }, issueListItemContent);
+                    if (issue.openedDate) {
+                        var issueDate = new Date(issue.openedDate);
+                        secondLine = "#" + issue.id + " opened by " + issue.openedBy +
+                            " on " + issueDate.toDateString() +
+                            " at " + ("00" + issueDate.getHours()).slice(-2) +
+                            ":" + ("00" + issueDate.getMinutes()).slice(-2);
+                    } else {
+                        secondLine = "&nbsp;";
+                    }
+
+                    if (issue.alreadyLinked) {
+                        domClass.add(issueListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");
+                        buttonName = "emptyButton";
+                        iconName = "check";
+                    } else {
+                        iconName = "link";
+                    }
                 }
+
+                ViewHelper.DrawListItem(issueListItem, firstLine, secondLine, buttonName, iconName);
             });
         },
 

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -10,12 +10,13 @@ define([
     "./DataStores/MainDataStore",
     "./RestServices/JazzRestService",
     "./RestServices/GitRestService",
+    "./ViewHelper",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewAndSelectIssues.html"
 ], function (declare, array, lang, dom, domClass, domConstruct, on, query,
-    MainDataStore, JazzRestService, GitRestService,
+    MainDataStore, JazzRestService, GitRestService, ViewHelper,
     _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectIssues",

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -189,7 +189,6 @@ define([
             domConstruct.empty(issuesListNode);
 
             array.forEach(this.viewIssues, function (issue) {
-                // TODO: This is where I need to add a class with lower alpha
                 var issueListItem = domConstruct.create("div", {
                     "class": "rtcGitConnectorViewAndSelectListItem",
                     "data-issue-id": issue.originalId

--- a/resources/ui/widget/js/ViewAndSelectIssues.js
+++ b/resources/ui/widget/js/ViewAndSelectIssues.js
@@ -354,28 +354,7 @@ define([
 
         // Sort the view issues by the openedDate
         sortViewIssuesByDate: function () {
-            var self = this;
-
-            // Create a temp array so that the date objects are only created once
-            var tempArray = this.viewIssues.map(function (el, i) {
-                return {
-                    index: i,
-                    value: new Date(el.openedDate).getTime()
-                };
-            });
-
-            // Sort the temp array
-            tempArray.sort(function (a, b) {
-                return b.value - a.value;
-            });
-
-            // Get a sorted version of the original array
-            var sortedArray = tempArray.map(function (el) {
-                return self.viewIssues[el.index];
-            });
-
-            // Use the sorted array
-            this.viewIssues = sortedArray;
+            this.viewIssues = ViewHelper.SortListDataByDate("openedDate", this.viewIssues);
         },
 
         // Filter the view issues using the filter text.

--- a/resources/ui/widget/js/ViewAndSelectRequests.js
+++ b/resources/ui/widget/js/ViewAndSelectRequests.js
@@ -335,28 +335,7 @@ define([
 
         // Sort the view requests by the openedDate
         sortViewRequestsByDate: function () {
-            var self = this;
-
-            // Create a temp array so that the date objects are only created once
-            var tempArray = this.viewRequests.map(function (el, i) {
-                return {
-                    index: i,
-                    value: new Date(el.openedDate).getTime()
-                };
-            });
-
-            // Sort the temp array
-            tempArray.sort(function (a, b) {
-                return b.value - a.value;
-            });
-
-            // Get a sorted version of the original array
-            var sortedArray = tempArray.map(function (el) {
-                return self.viewRequests[el.index];
-            });
-
-            // Use the sorted array
-            this.viewRequests = sortedArray;
+            this.viewRequests = ViewHelper.SortListDataByDate("openedDate", this.viewRequests);
         },
 
         // Filter the view requests using the filter text.

--- a/resources/ui/widget/js/ViewAndSelectRequests.js
+++ b/resources/ui/widget/js/ViewAndSelectRequests.js
@@ -222,19 +222,9 @@ define([
                 });
 
                 var firstLine = request.title;
-                var secondLine;
+                var secondLine = ViewHelper.GetIssueOrRequestDateString(request);
                 var buttonName = "";
                 var iconName;
-
-                if (request.openedDate) {
-                    var requestDate = new Date(request.openedDate);
-                    secondLine = "#" + request.id + " opened by " + request.openedBy +
-                        " on " + requestDate.toDateString() +
-                        " at " + ("00" + requestDate.getHours()).slice(-2) +
-                        ":" + ("00" + requestDate.getMinutes()).slice(-2);
-                } else {
-                    secondLine = "&nbsp;";
-                }
 
                 if (request.alreadyLinked) {
                     domClass.add(requestListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");

--- a/resources/ui/widget/js/ViewAndSelectRequests.js
+++ b/resources/ui/widget/js/ViewAndSelectRequests.js
@@ -10,12 +10,13 @@ define([
     "./DataStores/MainDataStore",
     "./RestServices/JazzRestService",
     "./RestServices/GitRestService",
+    "./ViewHelper",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewAndSelectRequests.html"
 ], function (declare, array, lang, dom, domClass, domConstruct, on, query,
-    MainDataStore, JazzRestService, GitRestService,
+    MainDataStore, JazzRestService, GitRestService, ViewHelper,
     _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectRequests",

--- a/resources/ui/widget/js/ViewAndSelectRequests.js
+++ b/resources/ui/widget/js/ViewAndSelectRequests.js
@@ -361,36 +361,11 @@ define([
 
         // Filter the view requests using the filter text.
         // Only keep requests that contain the filter text either
-        // in the request title or request author name or id or email
+        // in the request title or request author name or id or state
         filterViewRequestsByText: function (filterText) {
-            filterText = filterText.toLowerCase();
-            this.viewRequests = this.viewRequests.filter(function (request) {
-                request.id = request.id.toString();
-                return request.id.toLowerCase().indexOf(filterText) > -1 ||
-                    request.title.toLowerCase().indexOf(filterText) > -1 ||
-                    request.state.toLowerCase().indexOf(filterText) > -1 ||
-                    request.openedBy.toLowerCase().indexOf(filterText) > -1;
-            });
-            this._highlightFilterText(filterText, ["id", "title", "state", "openedBy"], this.viewRequests);
-        },
-
-        _highlightFilterText: function (filterText, filterBy, filterResult) {
-            for (var i=0; i < filterResult.length; i++) {
-                for (var j=0; j < filterBy.length; j++) {
-                    filterResult[i][filterBy[j]] = this._highlightTextInString(filterText, filterResult[i][filterBy[j]]);
-                }
-            }
-        },
-
-        _highlightTextInString: function (searchText, fullText) {
-            var startIndex;
-            if (searchText.toLowerCase() && (startIndex = fullText.toLowerCase().indexOf(searchText)) > -1) {
-                var beforeFound = fullText.slice(0, startIndex);
-                var found = fullText.slice(startIndex, startIndex + searchText.length);
-                var afterFound = this._highlightTextInString(searchText, fullText.slice(startIndex + searchText.length));
-                fullText = beforeFound + "<b class='rtcGitConnectorHighlightText'>" + found + "</b>" + afterFound;
-            }
-            return fullText;
+            this.viewRequests = ViewHelper.FilterListDataByText(filterText,
+                ["id", "title", "state", "openedBy"],
+                this.viewRequests);
         }
     });
 });

--- a/resources/ui/widget/js/ViewAndSelectRequests.js
+++ b/resources/ui/widget/js/ViewAndSelectRequests.js
@@ -221,42 +221,30 @@ define([
                     }
                 });
 
-                if (request.alreadyLinked) {
-                    var check = self.fontAwesome.icon({prefix: 'fas', iconName: 'check'});
-                    domClass.add(requestListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton emptyButton",
-                        innerHTML: check.html[0]
-                    }, requestListItem);
-                } else {
-                    var link = self.fontAwesome.icon({prefix: 'fas', iconName: 'link'});
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton",
-                        innerHTML: link.html[0]
-                    }, requestListItem);
-                }
-
-                var requestListItemContent = domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemContent"
-                }, requestListItem);
-
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine",
-                    innerHTML: request.title
-                }, requestListItemContent);
+                var firstLine = request.title;
+                var secondLine;
+                var buttonName = "";
+                var iconName;
 
                 if (request.openedDate) {
                     var requestDate = new Date(request.openedDate);
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "#" + request.id + " opened by " + request.openedBy + " on " + requestDate.toDateString() + " at " + ("00" + requestDate.getHours()).slice(-2) + ":" + ("00" + requestDate.getMinutes()).slice(-2)
-                    }, requestListItemContent);
+                    secondLine = "#" + request.id + " opened by " + request.openedBy +
+                        " on " + requestDate.toDateString() +
+                        " at " + ("00" + requestDate.getHours()).slice(-2) +
+                        ":" + ("00" + requestDate.getMinutes()).slice(-2);
                 } else {
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "&nbsp;"
-                    }, requestListItemContent);
+                    secondLine = "&nbsp;";
                 }
+
+                if (request.alreadyLinked) {
+                    domClass.add(requestListItem, "rtcGitConnectorViewAndSelectListItemAlreadyLinked");
+                    buttonName = "emptyButton";
+                    iconName = "check";
+                } else {
+                    iconName = "link";
+                }
+
+                ViewHelper.DrawListItem(requestListItem, firstLine, secondLine, buttonName, iconName);
             });
         },
 

--- a/resources/ui/widget/js/ViewAndSelectRequests.js
+++ b/resources/ui/widget/js/ViewAndSelectRequests.js
@@ -295,42 +295,18 @@ define([
                     innerHTML: "Select a request to view more details"
                 }, requestDetailsNode);
             } else {
-                this.addToDetailsViewNode(requestDetailsNode, "Title: ", request.title);
-                this.addToDetailsViewNode(requestDetailsNode, "State: ", request.state);
-                this.addToDetailsViewNode(requestDetailsNode, "Opened by: ", request.openedBy);
-                this.addToDetailsViewNode(requestDetailsNode, "Date opened: ", new Date(request.openedDate).toString());
-                this.addToDetailsViewNode(requestDetailsNode, "Request id: ", "#" + request.id);
+                ViewHelper.AddToDetailsViewNode(requestDetailsNode, "Title: ", request.title);
+                ViewHelper.AddToDetailsViewNode(requestDetailsNode, "State: ", request.state);
+                ViewHelper.AddToDetailsViewNode(requestDetailsNode, "Opened by: ", request.openedBy);
+                ViewHelper.AddToDetailsViewNode(requestDetailsNode, "Date opened: ", new Date(request.openedDate).toString());
+                ViewHelper.AddToDetailsViewNode(requestDetailsNode, "Request id: ", "#" + request.id);
                 var linkNode = domConstruct.create("a", {
                     innerHTML: "Open this request in a new tab",
                     href: request.webUrl,
                     target: "_blank"
                 });
-                this.addLinkToDetailsViewNode(requestDetailsNode, "Web Link: ", linkNode);
+                ViewHelper.AddLinkToDetailsViewNode(requestDetailsNode, "Web Link: ", linkNode);
             }
-        },
-
-        addToDetailsViewNode: function (detailsViewNode, label, value) {
-            var requestTitleNode = this.createDetailsViewSpan(detailsViewNode, label);
-            domConstruct.create("span", {
-                innerHTML: value
-            }, requestTitleNode);
-        },
-
-        addLinkToDetailsViewNode: function (detailsViewNode, label, linkNode) {
-            var requestTitleNode = this.createDetailsViewSpan(detailsViewNode, label);
-            domConstruct.place(linkNode, requestTitleNode);
-        },
-
-        createDetailsViewSpan: function (detailsViewNode, label) {
-            var requestTitleNode = domConstruct.create("span", {
-                "class": "rtcGitConnectorViewAndSelectDetailsSpan"
-            }, detailsViewNode);
-            domConstruct.create("span", {
-                "class": "rtcGitConnectorViewAndSelectDetailsLabel",
-                innerHTML: label
-            }, requestTitleNode);
-
-            return requestTitleNode;
         },
 
         // Sort the view requests by the openedDate

--- a/resources/ui/widget/js/ViewAndSelectRequests.js
+++ b/resources/ui/widget/js/ViewAndSelectRequests.js
@@ -197,7 +197,7 @@ define([
                 on(requestListItem, "click", function (event) {
                     var requestId = this.getAttribute("data-request-id");
 
-                    if (!request.alreadyLinked && self.isNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
+                    if (!request.alreadyLinked && ViewHelper.IsNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
                         // Remove the request with the specified id from the requests list in store and add to the selected list
                         if (requestId) {
                             var selectedRequest = null;
@@ -391,19 +391,6 @@ define([
                 fullText = beforeFound + "<b class='rtcGitConnectorHighlightText'>" + found + "</b>" + afterFound;
             }
             return fullText;
-        },
-
-        // Checks if the node or any of it's parents have the class name
-        isNodeInClass: function (node, className) {
-            if (node.classList && node.classList.contains(className)) {
-                return true;
-            }
-
-            if (node.parentNode) {
-                return this.isNodeInClass(node.parentNode, className);
-            }
-
-            return false;
         }
     });
 });

--- a/resources/ui/widget/js/ViewCommitsToLink.js
+++ b/resources/ui/widget/js/ViewCommitsToLink.js
@@ -111,12 +111,7 @@ define([
             });
 
             // Get the mainDialog and resize to fit the new content
-            var mainDialog = registry.byId("connectWithGitMainDialog");
-            var paneContentNode = query(".dijitDialogPaneContent", mainDialog.domNode)[0];
-            var originalScrollTop = paneContentNode.scrollTop;
-            mainDialog.resize();
-            mainDialog.resize();
-            paneContentNode.scrollTo(0, originalScrollTop);
+            ViewHelper.ResizeMainDialog();
         }
     });
 });

--- a/resources/ui/widget/js/ViewCommitsToLink.js
+++ b/resources/ui/widget/js/ViewCommitsToLink.js
@@ -67,7 +67,7 @@ define([
                 on(commitListItem, "click", function (event) {
                     var commitSha = this.getAttribute("data-commit-sha");
 
-                    if (self.isNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
+                    if (ViewHelper.IsNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
                         // Remove the commit with the specified sha from the commits to link list in store and add to the commits list
                         if (commitSha) {
                             var selectedCommit = null;
@@ -117,19 +117,6 @@ define([
             mainDialog.resize();
             mainDialog.resize();
             paneContentNode.scrollTo(0, originalScrollTop);
-        },
-
-        // Checks if the node or any of it's parents have the class name
-        isNodeInClass: function (node, className) {
-            if (node.classList && node.classList.contains(className)) {
-                return true;
-            }
-
-            if (node.parentNode) {
-                return this.isNodeInClass(node.parentNode, className);
-            }
-
-            return false;
         }
     });
 });

--- a/resources/ui/widget/js/ViewCommitsToLink.js
+++ b/resources/ui/widget/js/ViewCommitsToLink.js
@@ -83,11 +83,7 @@ define([
                 });
 
                 var firstLine = commit.message.split(/\r?\n/g)[0];
-                var commitDate = new Date(commit.authoredDate);
-                var secondLine = commit.authorName + " committed on "
-                    + commitDate.toDateString() + " at "
-                    + ("00" + commitDate.getHours()).slice(-2) + ":"
-                    + ("00" + commitDate.getMinutes()).slice(-2);
+                var secondLine = ViewHelper.GetCommitDateString(commit);
                 ViewHelper.DrawListItem(commitListItem, firstLine, secondLine, "removeButton", "trash");
             });
 

--- a/resources/ui/widget/js/ViewCommitsToLink.js
+++ b/resources/ui/widget/js/ViewCommitsToLink.js
@@ -7,14 +7,13 @@ define([
     "dojo/query",
     "./DataStores/MainDataStore",
     "./ViewHelper",
-    "dijit/registry",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewCommitsToLink.html"
 ], function (declare, array, domConstruct, domStyle, on, query,
     MainDataStore, ViewHelper,
-    registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
+    _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewCommitsToLink",
         [_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin],

--- a/resources/ui/widget/js/ViewCommitsToLink.js
+++ b/resources/ui/widget/js/ViewCommitsToLink.js
@@ -20,14 +20,9 @@ define([
     {
         templateString: template,
         mainDataStore: null,
-        fontAwesome: null,
 
         constructor: function () {
             this.mainDataStore = MainDataStore.getInstance();
-
-            if (typeof com_siemens_bt_jazz_rtcgitconnector_modules !== 'undefined') {
-                this.fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
-            }
         },
 
         startup: function () {
@@ -87,26 +82,13 @@ define([
                     }
                 });
 
-                var trash = self.fontAwesome.icon({prefix: 'fas', iconName: 'trash'});
-                domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemButton removeButton",
-                    innerHTML: trash.html[0]
-                }, commitListItem);
-
-                var commitListItemContent = domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemContent"
-                }, commitListItem);
-
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine",
-                    innerHTML: commit.message.split(/\r?\n/g)[0]
-                }, commitListItemContent);
-
+                var firstLine = commit.message.split(/\r?\n/g)[0];
                 var commitDate = new Date(commit.authoredDate);
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                    innerHTML: commit.authorName + " committed on " + commitDate.toDateString() + " at " + ("00" + commitDate.getHours()).slice(-2) + ":" + ("00" + commitDate.getMinutes()).slice(-2)
-                }, commitListItemContent);
+                var secondLine = commit.authorName + " committed on "
+                    + commitDate.toDateString() + " at "
+                    + ("00" + commitDate.getHours()).slice(-2) + ":"
+                    + ("00" + commitDate.getMinutes()).slice(-2);
+                ViewHelper.DrawListItem(commitListItem, firstLine, secondLine, "removeButton", "trash");
             });
 
             // Get the mainDialog and resize to fit the new content

--- a/resources/ui/widget/js/ViewCommitsToLink.js
+++ b/resources/ui/widget/js/ViewCommitsToLink.js
@@ -6,13 +6,14 @@ define([
     "dojo/on",
     "dojo/query",
     "./DataStores/MainDataStore",
+    "./ViewHelper",
     "dijit/registry",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewCommitsToLink.html"
 ], function (declare, array, domConstruct, domStyle, on, query,
-    MainDataStore,
+    MainDataStore, ViewHelper,
     registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewCommitsToLink",

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -5,6 +5,14 @@ define([
     return new function () {
         var self = this;
 
+        this.HighlightFilterText = function (filterText, filterBy, filterResult) {
+            for (var i=0; i < filterResult.length; i++) {
+                for (var j=0; j < filterBy.length; j++) {
+                    filterResult[i][filterBy[j]] = self.HighlightTextInString(filterText, filterResult[i][filterBy[j]]);
+                }
+            }
+        };
+
         this.HighlightTextInString = function (searchText, fullText) {
             var startIndex;
             if (searchText.toLowerCase() && (startIndex = fullText.toLowerCase().indexOf(searchText)) > -1) {

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -132,5 +132,27 @@ define([
                 innerHTML: secondLine
             }, listItemContent);
         };
+
+        // Create a string with information about who created the commit and when
+        this.GetCommitDateString = function (commit) {
+            var commitDateString;
+
+            if (commit.authoredDate) {
+                var commitDate = new Date(commit.authoredDate);
+                commitDateString = commit.authorName + " committed on "
+                    + commitDate.toDateString() + " at "
+                    + ("00" + commitDate.getHours()).slice(-2) + ":"
+                    + ("00" + commitDate.getMinutes()).slice(-2);
+            } else {
+                commitDateString = "&nbsp;";
+            }
+
+            return commitDateString;
+        };
+
+        // Create a string with information about who created the issue or request and when
+        this.GetIssueOrRequestDateString = function (issueOrRequest) {
+
+        };
     };
 });

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -156,10 +156,11 @@ define([
 
             if (issueOrRequest.openedDate) {
                 var issueOrRequestDate = new Date(issueOrRequest.openedDate);
-                issueOrRequestDateString = "#" + issueOrRequest.id + " opened by " + issueOrRequest.openedBy +
-                    " on " + issueOrRequestDate.toDateString() +
-                    " at " + ("00" + issueOrRequestDate.getHours()).slice(-2) +
-                    ":" + ("00" + issueOrRequestDate.getMinutes()).slice(-2);
+                issueOrRequestDateString = "#" + issueOrRequest.id + " opened by "
+                    + issueOrRequest.openedBy + " on "
+                    + issueOrRequestDate.toDateString() + " at "
+                    + ("00" + issueOrRequestDate.getHours()).slice(-2) + ":"
+                    + ("00" + issueOrRequestDate.getMinutes()).slice(-2);
             } else {
                 issueOrRequestDateString = "&nbsp;";
             }

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -1,6 +1,8 @@
 define([
-    "dojo/_base/declare"
-], function (declare) {
+    "dojo/_base/declare",
+    "dojo/query",
+    "dijit/registry"
+], function (declare, query, registry) {
     // Return an instance so that the functions can be used as if they were static
     return new function () {
         var self = this;
@@ -67,6 +69,18 @@ define([
             }
 
             return false;
+        };
+
+        // Resize the main dialog to fit the content. Reset the scroll
+        // height to the previous value afterwards (otherwise the
+        // scroll is reset to the top every time the dialog is resized).
+        this.ResizeMainDialog = function () {
+            var mainDialog = registry.byId("connectWithGitMainDialog");
+            var paneContentNode = query(".dijitDialogPaneContent", mainDialog.domNode)[0];
+            var originalScrollTop = paneContentNode.scrollTop;
+            mainDialog.resize();
+            mainDialog.resize(); // The second time it fixes the positioning
+            paneContentNode.scrollTo(0, originalScrollTop);
         };
     };
 });

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -108,5 +108,29 @@ define([
 
             return messageNode;
         };
+
+        // List item view node creators
+        this.DrawListItem = function (listItem, firstLine, secondLine, buttonName, iconName) {
+            var fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
+            var icon = fontAwesome.icon({ prefix: 'fas', iconName: iconName });
+            domConstruct.create("div", {
+                "class": "rtcGitConnectorViewAndSelectListItemButton " + buttonName,
+                innerHTML: icon.html[0]
+            }, listItem);
+
+            var listItemContent = domConstruct.create("div", {
+                "class": "rtcGitConnectorViewAndSelectListItemContent"
+            }, listItem);
+
+            domConstruct.create("span", {
+                "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine",
+                innerHTML: firstLine
+            }, listItemContent);
+
+            domConstruct.create("span", {
+                "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
+                innerHTML: secondLine
+            }, listItemContent);
+        };
     };
 });

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -152,7 +152,19 @@ define([
 
         // Create a string with information about who created the issue or request and when
         this.GetIssueOrRequestDateString = function (issueOrRequest) {
+            var issueOrRequestDateString;
 
+            if (issueOrRequest.openedDate) {
+                var issueOrRequestDate = new Date(issueOrRequest.openedDate);
+                issueOrRequestDateString = "#" + issueOrRequest.id + " opened by " + issueOrRequest.openedBy +
+                    " on " + issueOrRequestDate.toDateString() +
+                    " at " + ("00" + issueOrRequestDate.getHours()).slice(-2) +
+                    ":" + ("00" + issueOrRequestDate.getMinutes()).slice(-2);
+            } else {
+                issueOrRequestDateString = "&nbsp;";
+            }
+
+            return issueOrRequestDateString;
         };
     };
 });

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -9,31 +9,21 @@ define([
         // highlight the text where found.
         this.FilterListDataByText = function (filterText, filterBy, filterResult) {
             filterText = filterText.toLowerCase();
-            filterResult = filterResult.filter(function (item) {
+            return filterResult.filter(function (item) {
                 for (var i = 0; i < filterBy.length; i++) {
-                    if (item[filterBy[i]].toString().toLowerCase().indexOf(filterText) > -1) {
+                    var lowerCaseString = item[filterBy[i]].toString().toLowerCase();
+                    if (lowerCaseString.indexOf(filterText) > -1) {
+                        item[filterBy[i]] = self.HighlightTextInString(filterText, lowerCaseString);
                         return true;
                     }
                 }
-
                 return false;
             });
-            self.HighlightFilterText(filterText, filterBy, filterResult);
-
-            return filterResult;
-        };
-
-        this.HighlightFilterText = function (filterText, filterBy, filterResult) {
-            for (var i = 0; i < filterResult.length; i++) {
-                for (var j = 0; j < filterBy.length; j++) {
-                    filterResult[i][filterBy[j]] = self.HighlightTextInString(filterText, filterResult[i][filterBy[j]]);
-                }
-            }
         };
 
         this.HighlightTextInString = function (searchText, fullText) {
             var startIndex;
-            if (searchText.toLowerCase() && (startIndex = fullText.toLowerCase().indexOf(searchText)) > -1) {
+            if (searchText && (startIndex = fullText.indexOf(searchText)) > -1) {
                 var beforeFound = fullText.slice(0, startIndex);
                 var found = fullText.slice(startIndex, startIndex + searchText.length);
                 var afterFound = self.HighlightTextInString(searchText, fullText.slice(startIndex + searchText.length));

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -1,8 +1,9 @@
 define([
     "dojo/_base/declare",
+    "dojo/dom-construct",
     "dojo/query",
     "dijit/registry"
-], function (declare, query, registry) {
+], function (declare, domConstruct, query, registry) {
     // Return an instance so that the functions can be used as if they were static
     return new function () {
         var self = this;
@@ -81,6 +82,31 @@ define([
             mainDialog.resize();
             mainDialog.resize(); // The second time it fixes the positioning
             paneContentNode.scrollTo(0, originalScrollTop);
+        };
+
+        // Details view node creators
+        this.AddToDetailsViewNode = function (detailsViewNode, label, value) {
+            var messageNode = self.CreateDetailsViewSpan(detailsViewNode, label);
+            domConstruct.create("span", {
+                innerHTML: value
+            }, messageNode);
+        };
+
+        this.AddLinkToDetailsViewNode = function (detailsViewNode, label, linkNode) {
+            var messageNode = self.CreateDetailsViewSpan(detailsViewNode, label);
+            domConstruct.place(linkNode, messageNode);
+        };
+
+        this.CreateDetailsViewSpan = function (detailsViewNode, label) {
+            var messageNode = domConstruct.create("span", {
+                "class": "rtcGitConnectorViewAndSelectDetailsSpan"
+            }, detailsViewNode);
+            domConstruct.create("span", {
+                "class": "rtcGitConnectorViewAndSelectDetailsLabel",
+                innerHTML: label
+            }, messageNode);
+
+            return messageNode;
         };
     };
 });

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -5,10 +5,6 @@ define([
     return new function () {
         var self = this;
 
-        this.TestFunction = function (testString) {
-            console.log(testString);
-        };
-
         this.HighlightTextInString = function (searchText, fullText) {
             var startIndex;
             if (searchText.toLowerCase() && (startIndex = fullText.toLowerCase().indexOf(searchText)) > -1) {

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -3,8 +3,21 @@ define([
 ], function (declare) {
     // Return an instance so that the functions can be used as if they were static
     return new function () {
+        var self = this;
+
         this.TestFunction = function (testString) {
             console.log(testString);
+        };
+
+        this.HighlightTextInString = function (searchText, fullText) {
+            var startIndex;
+            if (searchText.toLowerCase() && (startIndex = fullText.toLowerCase().indexOf(searchText)) > -1) {
+                var beforeFound = fullText.slice(0, startIndex);
+                var found = fullText.slice(startIndex, startIndex + searchText.length);
+                var afterFound = self.HighlightTextInString(searchText, fullText.slice(startIndex + searchText.length));
+                fullText = beforeFound + "<b class='rtcGitConnectorHighlightText'>" + found + "</b>" + afterFound;
+            }
+            return fullText;
         };
     };
 });

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -5,9 +5,27 @@ define([
     return new function () {
         var self = this;
 
+        // Filter a list of items by the specified properties and
+        // highlight the text where found.
+        this.FilterListDataByText = function (filterText, filterBy, filterResult) {
+            filterText = filterText.toLowerCase();
+            filterResult = filterResult.filter(function (item) {
+                for (var i = 0; i < filterBy.length; i++) {
+                    if (item[filterBy[i]].toString().toLowerCase().indexOf(filterText) > -1) {
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+            self.HighlightFilterText(filterText, filterBy, filterResult);
+
+            return filterResult;
+        };
+
         this.HighlightFilterText = function (filterText, filterBy, filterResult) {
-            for (var i=0; i < filterResult.length; i++) {
-                for (var j=0; j < filterBy.length; j++) {
+            for (var i = 0; i < filterResult.length; i++) {
+                for (var j = 0; j < filterBy.length; j++) {
                     filterResult[i][filterBy[j]] = self.HighlightTextInString(filterText, filterResult[i][filterBy[j]]);
                 }
             }

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -1,0 +1,10 @@
+define([
+    "dojo/_base/declare"
+], function (declare) {
+    // Return an instance so that the functions can be used as if they were static
+    return new function () {
+        this.TestFunction = function (testString) {
+            console.log(testString);
+        };
+    };
+});

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -141,8 +141,8 @@ define([
                 var commitDate = new Date(commit.authoredDate);
                 commitDateString = commit.authorName + " committed on "
                     + commitDate.toDateString() + " at "
-                    + ("00" + commitDate.getHours()).slice(-2) + ":"
-                    + ("00" + commitDate.getMinutes()).slice(-2);
+                    + self.FrontPadWithZeros(commitDate.getHours()) + ":"
+                    + self.FrontPadWithZeros(commitDate.getMinutes());
             } else {
                 commitDateString = "&nbsp;";
             }
@@ -159,13 +159,18 @@ define([
                 issueOrRequestDateString = "#" + issueOrRequest.id + " opened by "
                     + issueOrRequest.openedBy + " on "
                     + issueOrRequestDate.toDateString() + " at "
-                    + ("00" + issueOrRequestDate.getHours()).slice(-2) + ":"
-                    + ("00" + issueOrRequestDate.getMinutes()).slice(-2);
+                    + self.FrontPadWithZeros(issueOrRequestDate.getHours()) + ":"
+                    + self.FrontPadWithZeros(issueOrRequestDate.getMinutes());
             } else {
                 issueOrRequestDateString = "&nbsp;";
             }
 
             return issueOrRequestDateString;
+        };
+
+        // Add zeros to the front if the passed in time has less than two digits
+        this.FrontPadWithZeros = function (hoursOrMinutes) {
+            return ("00" + hoursOrMinutes).slice(-2);
         };
     };
 });

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -5,8 +5,32 @@ define([
     return new function () {
         var self = this;
 
+        // Sort a list of items by the date contained in the specified property
+        this.SortListDataByDate = function (dateProperty, listData) {
+            // Create a temp array so that the date objects are only created once
+            var tempArray = listData.map(function (el, i) {
+                return {
+                    index: i,
+                    value: new Date(el[dateProperty]).getTime()
+                };
+            });
+
+            // Sort the temp array
+            tempArray.sort(function (a, b) {
+                return b.value - a.value;
+            });
+
+            // Get a sorted version of the original array
+            var sortedArray = tempArray.map(function (el) {
+                return listData[el.index];
+            });
+
+            // Return the sorted array
+            return sortedArray;
+        };
+
         // Filter a list of items by the specified properties and
-        // highlight the text where found.
+        // highlight the text where found
         this.FilterListDataByText = function (filterText, filterBy, filterResult) {
             filterText = filterText.toLowerCase();
             return filterResult.filter(function (item) {

--- a/resources/ui/widget/js/ViewHelper.js
+++ b/resources/ui/widget/js/ViewHelper.js
@@ -23,5 +23,18 @@ define([
             }
             return fullText;
         };
+
+        // Checks if the node or any of it's parents have the class name
+        this.IsNodeInClass = function (node, className) {
+            if (node.classList && node.classList.contains(className)) {
+                return true;
+            }
+
+            if (node.parentNode) {
+                return self.IsNodeInClass(node.parentNode, className);
+            }
+
+            return false;
+        };
     };
 });

--- a/resources/ui/widget/js/ViewIssuesToLink.js
+++ b/resources/ui/widget/js/ViewIssuesToLink.js
@@ -20,14 +20,9 @@ define([
     {
         templateString: template,
         mainDataStore: null,
-        fontAwesome: null,
 
         constructor: function () {
             this.mainDataStore = MainDataStore.getInstance();
-
-            if (typeof com_siemens_bt_jazz_rtcgitconnector_modules !== 'undefined') {
-                this.fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
-            }
         },
 
         startup: function () {
@@ -88,41 +83,26 @@ define([
                     }
                 });
 
-                if (issue.id < 0) {
-                    var trash = self.fontAwesome.icon({prefix: 'fas', iconName: 'times'});
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton deleteButton",
-                        innerHTML: trash.html[0]
-                    }, issueListItem);
-                } else {
-                    var trash = self.fontAwesome.icon({prefix: 'fas', iconName: 'trash'});
-                    domConstruct.create("div", {
-                        "class": "rtcGitConnectorViewAndSelectListItemButton removeButton",
-                        innerHTML: trash.html[0]
-                    }, issueListItem);
-                }
-
-                var issueListItemContent = domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemContent"
-                }, issueListItem);
-
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine",
-                    innerHTML: issue.title
-                }, issueListItemContent);
+                var firstLine = issue.title;
+                var secondLine;
+                var buttonName;
+                var iconName;
 
                 if (issue.id < 0) {
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "This will create a new issue in " + gitHost + " using the information from the current work item"
-                    }, issueListItemContent);
+                    secondLine = "This will create a new issue in " + gitHost + " using the information from the current work item";
+                    buttonName = "deleteButton";
+                    iconName = "times";
                 } else {
                     var issueDate = new Date(issue.openedDate);
-                    domConstruct.create("span", {
-                        "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                        innerHTML: "#" + issue.id + " opened by " + issue.openedBy + " on " + issueDate.toDateString() + " at " + ("00" + issueDate.getHours()).slice(-2) + ":" + ("00" + issueDate.getMinutes()).slice(-2)
-                    }, issueListItemContent);
+                    secondLine = "#" + issue.id + " opened by " + issue.openedBy +
+                        " on " + issueDate.toDateString() +
+                        " at " + ("00" + issueDate.getHours()).slice(-2) +
+                        ":" + ("00" + issueDate.getMinutes()).slice(-2);
+                    buttonName = "removeButton";
+                    iconName = "trash";
                 }
+                
+                ViewHelper.DrawListItem(issueListItem, firstLine, secondLine, buttonName, iconName);
             });
 
             // Get the mainDialog and resize to fit the new content

--- a/resources/ui/widget/js/ViewIssuesToLink.js
+++ b/resources/ui/widget/js/ViewIssuesToLink.js
@@ -93,11 +93,7 @@ define([
                     buttonName = "deleteButton";
                     iconName = "times";
                 } else {
-                    var issueDate = new Date(issue.openedDate);
-                    secondLine = "#" + issue.id + " opened by " + issue.openedBy +
-                        " on " + issueDate.toDateString() +
-                        " at " + ("00" + issueDate.getHours()).slice(-2) +
-                        ":" + ("00" + issueDate.getMinutes()).slice(-2);
+                    secondLine = ViewHelper.GetIssueOrRequestDateString(issue);
                     buttonName = "removeButton";
                     iconName = "trash";
                 }

--- a/resources/ui/widget/js/ViewIssuesToLink.js
+++ b/resources/ui/widget/js/ViewIssuesToLink.js
@@ -7,14 +7,13 @@ define([
     "dojo/query",
     "./DataStores/MainDataStore",
     "./ViewHelper",
-    "dijit/registry",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewIssuesToLink.html"
 ], function (declare, array, domConstruct, domStyle, on, query,
     MainDataStore, ViewHelper,
-    registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
+    _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewIssuesToLink",
         [_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin],

--- a/resources/ui/widget/js/ViewIssuesToLink.js
+++ b/resources/ui/widget/js/ViewIssuesToLink.js
@@ -68,7 +68,7 @@ define([
                 on(issueListItem, "click", function (event) {
                     var issueId = this.getAttribute("data-issue-id");
 
-                    if (self.isNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
+                    if (ViewHelper.IsNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
                         // Remove the issue with the specified id from the issues to link list in store and add to the issues list
                         if (issueId) {
                             var selectedIssue = null;
@@ -133,19 +133,6 @@ define([
             mainDialog.resize();
             mainDialog.resize();
             paneContentNode.scrollTo(0, originalScrollTop);
-        },
-
-        // Checks if the node or any of it's parents have the class name
-        isNodeInClass: function (node, className) {
-            if (node.classList && node.classList.contains(className)) {
-                return true;
-            }
-
-            if (node.parentNode) {
-                return this.isNodeInClass(node.parentNode, className);
-            }
-
-            return false;
         }
     });
 });

--- a/resources/ui/widget/js/ViewIssuesToLink.js
+++ b/resources/ui/widget/js/ViewIssuesToLink.js
@@ -127,12 +127,7 @@ define([
             });
 
             // Get the mainDialog and resize to fit the new content
-            var mainDialog = registry.byId("connectWithGitMainDialog");
-            var paneContentNode = query(".dijitDialogPaneContent", mainDialog.domNode)[0];
-            var originalScrollTop = paneContentNode.scrollTop;
-            mainDialog.resize();
-            mainDialog.resize();
-            paneContentNode.scrollTo(0, originalScrollTop);
+            ViewHelper.ResizeMainDialog();
         }
     });
 });

--- a/resources/ui/widget/js/ViewIssuesToLink.js
+++ b/resources/ui/widget/js/ViewIssuesToLink.js
@@ -6,13 +6,14 @@ define([
     "dojo/on",
     "dojo/query",
     "./DataStores/MainDataStore",
+    "./ViewHelper",
     "dijit/registry",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewIssuesToLink.html"
 ], function (declare, array, domConstruct, domStyle, on, query,
-    MainDataStore,
+    MainDataStore, ViewHelper,
     registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewIssuesToLink",

--- a/resources/ui/widget/js/ViewIssuesToLink.js
+++ b/resources/ui/widget/js/ViewIssuesToLink.js
@@ -97,7 +97,7 @@ define([
                     buttonName = "removeButton";
                     iconName = "trash";
                 }
-                
+
                 ViewHelper.DrawListItem(issueListItem, firstLine, secondLine, buttonName, iconName);
             });
 

--- a/resources/ui/widget/js/ViewRequestsToLink.js
+++ b/resources/ui/widget/js/ViewRequestsToLink.js
@@ -111,12 +111,7 @@ define([
             });
 
             // Get the mainDialog and resize to fit the new content
-            var mainDialog = registry.byId("connectWithGitMainDialog");
-            var paneContentNode = query(".dijitDialogPaneContent", mainDialog.domNode)[0];
-            var originalScrollTop = paneContentNode.scrollTop;
-            mainDialog.resize();
-            mainDialog.resize();
-            paneContentNode.scrollTo(0, originalScrollTop);
+            ViewHelper.ResizeMainDialog();
         }
     });
 });

--- a/resources/ui/widget/js/ViewRequestsToLink.js
+++ b/resources/ui/widget/js/ViewRequestsToLink.js
@@ -6,13 +6,14 @@ define([
     "dojo/on",
     "dojo/query",
     "./DataStores/MainDataStore",
+    "./ViewHelper",
     "dijit/registry",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewRequestsToLink.html"
 ], function (declare, array, domConstruct, domStyle, on, query,
-    MainDataStore,
+    MainDataStore, ViewHelper,
     registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewRequestsToLink",

--- a/resources/ui/widget/js/ViewRequestsToLink.js
+++ b/resources/ui/widget/js/ViewRequestsToLink.js
@@ -7,14 +7,13 @@ define([
     "dojo/query",
     "./DataStores/MainDataStore",
     "./ViewHelper",
-    "dijit/registry",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!../templates/ViewRequestsToLink.html"
 ], function (declare, array, domConstruct, domStyle, on, query,
     MainDataStore, ViewHelper,
-    registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
+    _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewRequestsToLink",
         [_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin],

--- a/resources/ui/widget/js/ViewRequestsToLink.js
+++ b/resources/ui/widget/js/ViewRequestsToLink.js
@@ -20,14 +20,9 @@ define([
     {
         templateString: template,
         mainDataStore: null,
-        fontAwesome: null,
 
         constructor: function () {
             this.mainDataStore = MainDataStore.getInstance();
-
-            if (typeof com_siemens_bt_jazz_rtcgitconnector_modules !== 'undefined') {
-                this.fontAwesome = com_siemens_bt_jazz_rtcgitconnector_modules.FontAwesome;
-            }
         },
 
         startup: function () {
@@ -87,26 +82,11 @@ define([
                     }
                 });
 
-                var trash = self.fontAwesome.icon({prefix: 'fas', iconName: 'trash'});
-                domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemButton removeButton",
-                    innerHTML: trash.html[0]
-                }, requestListItem);
-
-                var requestListItemContent = domConstruct.create("div", {
-                    "class": "rtcGitConnectorViewAndSelectListItemContent"
-                }, requestListItem);
-
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine",
-                    innerHTML: request.title
-                }, requestListItemContent);
-
                 var requestDate = new Date(request.openedDate);
-                domConstruct.create("span", {
-                    "class": "rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine",
-                    innerHTML: "#" + request.id + " opened by " + request.openedBy + " on " + requestDate.toDateString() + " at " + ("00" + requestDate.getHours()).slice(-2) + ":" + ("00" + requestDate.getMinutes()).slice(-2)
-                }, requestListItemContent);
+                var secondLine = "#" + request.id + " opened by " + request.openedBy + " on "
+                    + requestDate.toDateString() + " at " + ("00" + requestDate.getHours()).slice(-2)
+                    + ":" + ("00" + requestDate.getMinutes()).slice(-2);
+                ViewHelper.DrawListItem(requestListItem, request.title, secondLine, "removeButton", "trash");
             });
 
             // Get the mainDialog and resize to fit the new content

--- a/resources/ui/widget/js/ViewRequestsToLink.js
+++ b/resources/ui/widget/js/ViewRequestsToLink.js
@@ -83,9 +83,10 @@ define([
                 });
 
                 var requestDate = new Date(request.openedDate);
-                var secondLine = "#" + request.id + " opened by " + request.openedBy + " on "
-                    + requestDate.toDateString() + " at " + ("00" + requestDate.getHours()).slice(-2)
-                    + ":" + ("00" + requestDate.getMinutes()).slice(-2);
+                var secondLine = "#" + request.id + " opened by " + request.openedBy +
+                    " on " + requestDate.toDateString() +
+                    " at " + ("00" + requestDate.getHours()).slice(-2) +
+                    ":" + ("00" + requestDate.getMinutes()).slice(-2);
                 ViewHelper.DrawListItem(requestListItem, request.title, secondLine, "removeButton", "trash");
             });
 

--- a/resources/ui/widget/js/ViewRequestsToLink.js
+++ b/resources/ui/widget/js/ViewRequestsToLink.js
@@ -67,7 +67,7 @@ define([
                 on(requestListItem, "click", function (event) {
                     var requestId = this.getAttribute("data-request-id");
 
-                    if (self.isNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
+                    if (ViewHelper.IsNodeInClass(event.target, "rtcGitConnectorViewAndSelectListItemButton")) {
                         // Remove the request with the specified id from the requests to link list in store and add to the requests list
                         if (requestId) {
                             var selectedRequest = null;
@@ -117,19 +117,6 @@ define([
             mainDialog.resize();
             mainDialog.resize();
             paneContentNode.scrollTo(0, originalScrollTop);
-        },
-
-        // Checks if the node or any of it's parents have the class name
-        isNodeInClass: function (node, className) {
-            if (node.classList && node.classList.contains(className)) {
-                return true;
-            }
-
-            if (node.parentNode) {
-                return this.isNodeInClass(node.parentNode, className);
-            }
-
-            return false;
         }
     });
 });

--- a/resources/ui/widget/js/ViewRequestsToLink.js
+++ b/resources/ui/widget/js/ViewRequestsToLink.js
@@ -82,11 +82,7 @@ define([
                     }
                 });
 
-                var requestDate = new Date(request.openedDate);
-                var secondLine = "#" + request.id + " opened by " + request.openedBy +
-                    " on " + requestDate.toDateString() +
-                    " at " + ("00" + requestDate.getHours()).slice(-2) +
-                    ":" + ("00" + requestDate.getMinutes()).slice(-2);
+                var secondLine = ViewHelper.GetIssueOrRequestDateString(request);
                 ViewHelper.DrawListItem(requestListItem, request.title, secondLine, "removeButton", "trash");
             });
 

--- a/resources/ui/widget/templates/ViewAndSelectIssues.html
+++ b/resources/ui/widget/templates/ViewAndSelectIssues.html
@@ -16,7 +16,7 @@
     <br />
     <input id="viewAndSelectIssuesFilterInput"
         class="viewAndSelectFilterInput"
-        placeholder="Filter issues by title, author, id..."
+        placeholder="Filter issues by title, author, state, id..."
         data-dojo-type="dijit/form/TextBox"
         data-dojo-attach-point="issuesFilterInput"
         data-dojo-props="trim:true, intermediateChanges:true">

--- a/resources/ui/widget/templates/ViewAndSelectRequests.html
+++ b/resources/ui/widget/templates/ViewAndSelectRequests.html
@@ -16,7 +16,7 @@
     <br />
     <input id="viewAndSelectRequestsFilterInput"
         class="viewAndSelectFilterInput"
-        placeholder="Filter requests by title, author, id..."
+        placeholder="Filter requests by title, author, state, id..."
         data-dojo-type="dijit/form/TextBox"
         data-dojo-attach-point="requestsFilterInput"
         data-dojo-props="trim:true, intermediateChanges:true">


### PR DESCRIPTION
Added a central location (ViewHelper) for code that was previously duplicated in the multiple view rendering files.

This takes care of the obvious and simple duplication problems in these files. Larger design changes would be needed to refactor further and are not included in this pull request.

Refactoring of the rest services is also not included. I would prefer to first upgrade the gitlab library before refactoring the code.