### PR TITLE
Update gitlab api library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,14 +1652,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1674,20 +1672,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1804,8 +1799,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1817,7 +1811,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1832,7 +1825,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1840,14 +1832,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -1866,7 +1856,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -1947,8 +1936,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1960,7 +1948,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2082,7 +2069,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,6 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@babel/runtime": {
-            "version": "7.0.0-beta.46",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
-            "integrity": "sha512-/3a3USMKk54BEHhDgY8rtxtaQOs4bp4aQwo6SDtdwmrXmgSgEusWuXNX5oIs/nwzmTD9o8wz2EyAjA+uHDMmJA==",
-            "requires": {
-                "core-js": "^2.5.3",
-                "regenerator-runtime": "^0.11.1"
-            }
-        },
         "@fortawesome/fontawesome": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome/-/fontawesome-1.1.5.tgz",
@@ -769,11 +760,6 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
-        "core-js": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-            "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -945,6 +931,15 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
         },
+        "define-properties": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "requires": {
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
+            }
+        },
         "define-property": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -1027,6 +1022,11 @@
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
             }
+        },
+        "dom-walk": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
         },
         "domain-browser": {
             "version": "1.2.0",
@@ -1121,6 +1121,28 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+            "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+            "requires": {
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+            "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+            "requires": {
+                "is-callable": "^1.1.1",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.1"
             }
         },
         "es5-ext": {
@@ -1518,11 +1540,24 @@
                 "readable-stream": "^2.0.4"
             }
         },
+        "for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -1617,12 +1652,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1637,17 +1674,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1764,7 +1804,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1776,6 +1817,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1790,6 +1832,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1797,12 +1840,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -1821,6 +1866,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -1901,7 +1947,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1913,6 +1960,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2034,6 +2082,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2105,6 +2154,11 @@
                 }
             }
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
         "get-caller-file": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -2129,6 +2183,77 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
                 "assert-plus": "^1.0.0"
+            }
+        },
+        "gitlab": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/gitlab/-/gitlab-3.5.0.tgz",
+            "integrity": "sha512-Bj2cJywT5TRQAWHAIa4S+n6HiBwEsCwnLDsIyfVL6LiF3ufA+Th87VhkDB+DE109Dl6Lrf35fvNFLSJ7jYpvug==",
+            "requires": {
+                "@babel/runtime": "^7.0.0-beta.51",
+                "humps": "^2.0.1",
+                "lodash.pick": "^4.4.0",
+                "parse-link-header": "^1.0.1",
+                "qs": "^6.5.2",
+                "request": "^2.87.0",
+                "request-promise": "^4.2.2",
+                "request-promise-core": "^1.1.1",
+                "url-join": "^4.0.0",
+                "util.promisify": "^1.0.0",
+                "xhr": "^2.5.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.0.0-beta.52",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.52.tgz",
+                    "integrity": "sha1-PztCuCuStOGig/x43xuy/Uuo0Mc=",
+                    "requires": {
+                        "core-js": "^2.5.7",
+                        "regenerator-runtime": "^0.12.0"
+                    }
+                },
+                "core-js": {
+                    "version": "2.5.7",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+                    "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                },
+                "regenerator-runtime": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
+                    "integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w=="
+                },
+                "request": {
+                    "version": "2.87.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+                    "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
+                    }
+                }
             }
         },
         "glob": {
@@ -2173,6 +2298,22 @@
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
+                }
+            }
+        },
+        "global": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+            "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+            "requires": {
+                "min-document": "^2.19.0",
+                "process": "~0.5.1"
+            },
+            "dependencies": {
+                "process": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+                    "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
                 }
             }
         },
@@ -2268,6 +2409,14 @@
             "requires": {
                 "ajv": "^5.1.0",
                 "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "requires": {
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -2502,6 +2651,11 @@
                 "builtin-modules": "^1.0.0"
             }
         },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+        },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -2510,6 +2664,11 @@
             "requires": {
                 "kind-of": "^3.0.2"
             }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -2550,6 +2709,11 @@
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
+        },
+        "is-function": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+            "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
         },
         "is-glob": {
             "version": "4.0.0",
@@ -2595,11 +2759,24 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+            "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -2947,6 +3124,14 @@
             "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
             "dev": true
         },
+        "min-document": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "requires": {
+                "dom-walk": "^0.1.0"
+            }
+        },
         "minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -3101,20 +3286,6 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
             "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         },
-        "node-gitlab-api": {
-            "version": "2.2.8",
-            "resolved": "https://registry.npmjs.org/node-gitlab-api/-/node-gitlab-api-2.2.8.tgz",
-            "integrity": "sha512-wc/2/rnfB1O/3aCz0E6LoFY83KkfAsjvHYFQCAf+OEtRwxmDxEMFKihW9VNL6hHWNDFsV+QE16KkpimdKgngOQ==",
-            "requires": {
-                "@babel/runtime": "^7.0.0-beta.42",
-                "humps": "^2.0.1",
-                "lodash.pick": "^4.4.0",
-                "parse-link-header": "^1.0.1",
-                "request": "^2.85.0",
-                "request-promise": "^4.2.2",
-                "url-join": "^4.0.0"
-            }
-        },
         "node-libs-browser": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
@@ -3233,6 +3404,11 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+        },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -3240,6 +3416,15 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
             }
         },
         "object.pick": {
@@ -3371,6 +3556,15 @@
                 "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3"
+            }
+        },
+        "parse-headers": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+            "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+            "requires": {
+                "for-each": "^0.3.2",
+                "trim": "0.0.1"
             }
         },
         "parse-json": {
@@ -3649,11 +3843,6 @@
                 "readable-stream": "^2.0.2",
                 "set-immediate-shim": "^1.0.1"
             }
-        },
-        "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
         "regex-not": {
             "version": "1.0.2",
@@ -4384,6 +4573,11 @@
                 }
             }
         },
+        "trim": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+            "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+        },
         "tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -4679,6 +4873,15 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
+        },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
         },
         "uuid": {
             "version": "3.2.1",
@@ -5004,6 +5207,17 @@
             "requires": {
                 "async-limiter": "~1.0.0",
                 "safe-buffer": "~5.1.0"
+            }
+        },
+        "xhr": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+            "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+            "requires": {
+                "global": "~4.3.0",
+                "is-function": "^1.0.1",
+                "parse-headers": "^2.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
         "base64-js": "^1.2.1",
         "buffer": "^5.0.7",
         "clipboard": "^2.0.1",
+        "gitlab": "^3.5.0",
         "gzip-js": "^0.3.2",
         "handlebars": "^4.0.11",
-        "node-gitlab-api": "^2.2.3",
         "turndown": "^4.0.2"
     },
     "devDependencies": {

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -573,7 +573,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.mergeRequests.show(giturl.joined, requestId).then(function (response) {
+                gitlab.MergeRequests.show(giturl.joined, requestId).then(function (response) {
                     var convertedRequests = [];
                     convertedRequests.push(RequestModel.CreateFromGitLabRequest(response, alreadyLinkedUrls));
                     deferred.resolve(convertedRequests);

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -122,7 +122,7 @@ define([
             tags += "from-rtc-work-item";
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: accessToken
             });
 
@@ -283,7 +283,7 @@ define([
             var giturl = this._createUrlInformation(params.selectedGitRepository.url);
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: params.accessToken
             });
 
@@ -415,7 +415,7 @@ define([
             var giturl = this._createUrlInformation(selectedGitRepository.url);
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: accessToken
             });
 
@@ -492,7 +492,7 @@ define([
             var giturl = this._createUrlInformation(selectedGitRepository.url);
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: accessToken
             });
 
@@ -565,7 +565,7 @@ define([
             var giturl = this._createUrlInformation(selectedGitRepository.url);
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: accessToken
             });
 
@@ -647,7 +647,6 @@ define([
             var parts = this._getUrlPartsFromPath(sanitized);
             // as mentioned below, this should be a member function
             // or maybe not even... not quite sure yet about this one
-            //var proxy = this._formatUrlWithProxy()
 
             return {
                 original : original,
@@ -665,7 +664,7 @@ define([
             var deferred = new Deferred();
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: accessToken
             });
 
@@ -748,7 +747,7 @@ define([
             var deferred = new Deferred();
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: accessToken
             });
 
@@ -831,7 +830,7 @@ define([
             var deferred = new Deferred();
 
             var gitlab = this.gitLabApi({
-                url: this._formatUrlWithProxy(giturl.origin),
+                url: giturl.origin,
                 token: accessToken
             });
 
@@ -928,7 +927,7 @@ define([
             } else if (gitHost === this.gitLabString) {
                 // Check access token with GitLab
                 var gitlab = this.gitLabApi({
-                    url: this._formatUrlWithProxy(this._getOriginFromUrlObject(gitRepositoryUrl)),
+                    url: this._getOriginFromUrlObject(gitRepositoryUrl),
                     token: accessToken
                 });
                 gitlab.users.current().then(function (response) {
@@ -947,14 +946,6 @@ define([
         // Gets the origin without a trailing slash
         _getOriginFromUrlObject: function (url) {
             return url.scheme + "://" + url.host + (url.port ? ":" + url.port : "");
-        },
-
-        // Format url with jazz proxy for properly authenticated access to remote host
-        // This should be a member function of a future "giturl" class
-        _formatUrlWithProxy: function (url) {
-            var proxyUrl = new URL(net.jazz.ajax._contextRoot + "/proxy?uri=", window.location.origin);
-            return proxyUrl.href + encodeURIComponent(url);
-            return url;
         },
 
         // Remove the ".git" suffix from the repository name if present

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -842,7 +842,8 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.mergeRequests.all(giturl.joined, {
+                gitlab.MergeRequests.all({
+                    projectId: giturl.joined,
                     max_pages: 1,
                     per_page: 100
                 }).then(function (response) {

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -162,13 +162,8 @@ define([
         getGitLabIssueTemplate: function (gitlab, projectId) {
             var deferred = new Deferred();
             var filePath = ".gitlab/issue_templates/" + this.issueTemplateName;
-            var url = "projects/" + encodeURIComponent(projectId) +
-                "/repository/files/" + encodeURIComponent(filePath) + "/raw?ref=master";
 
-            // Use the get function directly instead of the "projects.repository.files.showRaw" function
-            // This is a workaround so that the jazz proxy correctly sends the "ref" parameter as a
-            // query parameter
-            gitlab.get(encodeURIComponent(url), {}).then(function (response) {
+            gitlab.projects.repository.files.showRaw(projectId, filePath, "master").then(function (response) {
                 deferred.resolve(response);
             }, function (error) {
                 deferred.reject("Couldn't get the issue template from GitLab. Error: " + (error.message || error));

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -143,7 +143,7 @@ define([
                     var renderedTemplate = new TemplateService()
                         .renderTemplateWithWorkItem(templateString, workItem);
 
-                    gitlab.projects.issues.create(encodeURIComponent(giturl.joined), {
+                    gitlab.projects.issues.create(giturl.joined, {
                         title: workItem.object.attributes.summary.content,
                         description: renderedTemplate,
                         labels: tags
@@ -324,7 +324,7 @@ define([
         addBackLinksToGitLabCommits: function (gitlab, path, sha, commentBody) {
             var deferred = new Deferred();
 
-            gitlab.projects.repository.commits.comments.create(encodeURIComponent(path), sha, commentBody).then(function (response) {
+            gitlab.projects.repository.commits.comments.create(path, sha, commentBody).then(function (response) {
                 deferred.resolve(response);
             }, function (error) {
                 deferred.reject("Couldn't add a comment to the GitLab commit. Error: " + (error.error.message || error.error));
@@ -336,7 +336,7 @@ define([
         addBackLinksToGitLabIssues: function (gitlab, path, id, commentBody) {
             var deferred = new Deferred();
 
-            gitlab.projects.issues.notes.create(encodeURIComponent(path), id, {
+            gitlab.projects.issues.notes.create(path, id, {
                 body: commentBody
             }).then(function (response) {
                 deferred.resolve(response);
@@ -350,7 +350,7 @@ define([
         addBackLinksToGitLabRequests: function (gitlab, path, id, commentBody) {
             var deferred = new Deferred();
 
-            gitlab.projects.mergeRequests.notes.create(encodeURIComponent(path), id, {
+            gitlab.projects.mergeRequests.notes.create(path, id, {
                 body: commentBody
             }).then(function (response) {
                 deferred.resolve(response);
@@ -422,7 +422,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.repository.commits.show(encodeURIComponent(giturl.joined), commitSha).then(function (response) {
+                gitlab.projects.repository.commits.show(giturl.joined, commitSha).then(function (response) {
                     var commitUrlPath = giturl.repo + "/commit/";
                     var convertedCommits = [];
                     convertedCommits.push(CommitModel.CreateFromGitLabCommit(response, commitUrlPath, alreadyLinkedUrls));
@@ -499,7 +499,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.issues.show(encodeURIComponent(giturl.joined), issueId).then(function (response) {
+                gitlab.projects.issues.show(giturl.joined, issueId).then(function (response) {
                     var convertedIssues = [];
                     convertedIssues.push(IssueModel.CreateFromGitLabIssue(response, alreadyLinkedUrls));
                     deferred.resolve(convertedIssues);
@@ -572,7 +572,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.mergeRequests.show(encodeURIComponent(giturl.joined), requestId).then(function (response) {
+                gitlab.projects.mergeRequests.show(giturl.joined, requestId).then(function (response) {
                     var convertedRequests = [];
                     convertedRequests.push(RequestModel.CreateFromGitLabRequest(response, alreadyLinkedUrls));
                     deferred.resolve(convertedRequests);
@@ -672,7 +672,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.repository.commits.all(encodeURIComponent(giturl.joined), {
+                gitlab.projects.repository.commits.all(giturl.joined, {
                     max_pages: 1,
                     per_page: 100
                 }).then(function (response) {
@@ -757,7 +757,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.issues.all(encodeURIComponent(giturl.joined), {
+                gitlab.projects.issues.all(giturl.joined, {
                     max_pages: 1,
                     per_page: 100
                 }).then(function (response) {
@@ -838,7 +838,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.mergeRequests.all(encodeURIComponent(giturl.joined), {
+                gitlab.projects.mergeRequests.all(giturl.joined, {
                     max_pages: 1,
                     per_page: 100
                 }).then(function (response) {
@@ -954,6 +954,7 @@ define([
         _formatUrlWithProxy: function (url) {
             var proxyUrl = new URL(net.jazz.ajax._contextRoot + "/proxy?uri=", window.location.origin);
             return proxyUrl.href + encodeURIComponent(url);
+            return url;
         },
 
         // Remove the ".git" suffix from the repository name if present

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -421,7 +421,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.repository.commits.show(giturl.joined, commitSha).then(function (response) {
+                gitlab.Commits.show(giturl.joined, commitSha).then(function (response) {
                     var commitUrlPath = giturl.repo + "/commit/";
                     var convertedCommits = [];
                     convertedCommits.push(CommitModel.CreateFromGitLabCommit(response, commitUrlPath, alreadyLinkedUrls));

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -3,6 +3,7 @@ define([
     "dojo/_base/url",
     "dojo/_base/array",
     "dojo/json",
+    "dojo/request/xhr",
     "dojo/Deferred",
     "dojo/DeferredList",
     "../Models/CommitModel",
@@ -10,7 +11,7 @@ define([
     "../Models/RequestModel",
     "../HandlebarsTemplates/TemplateService",
     "../HandlebarsTemplates/DefaultIssueTemplate"
-], function (declare, url, array, json, Deferred, DeferredList,
+], function (declare, url, array, json, xhr, Deferred, DeferredList,
     CommitModel, IssueModel, RequestModel,
     TemplateService, DefaultIssueTemplate) {
     var _instance = null;
@@ -888,10 +889,7 @@ define([
         // Make a request for a single public project from the gitlab api.
         // Return true if the request was successful, otherwise false.
         isGitLabRepository: function (gitRepositoryUrl) {
-            var url = this._getOriginFromUrlObject(gitRepositoryUrl) + "/api/v4/projects?per_page=1";
-
-            return jazz.client.xhrGet({
-                url: url,
+            return xhr.get(this._getOriginFromUrlObject(gitRepositoryUrl) + "/api/v4/projects", {
                 query: {
                     per_page: 1
                 },

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -499,7 +499,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.issues.show(giturl.joined, issueId).then(function (response) {
+                gitlab.Issues.show(giturl.joined, issueId).then(function (response) {
                     var convertedIssues = [];
                     convertedIssues.push(IssueModel.CreateFromGitLabIssue(response, alreadyLinkedUrls));
                     deferred.resolve(convertedIssues);

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -759,7 +759,8 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.issues.all(giturl.joined, {
+                gitlab.Issues.all({
+                    projectId: giturl.joined,
                     max_pages: 1,
                     per_page: 100
                 }).then(function (response) {

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -932,7 +932,7 @@ define([
                     token: accessToken,
                     useXMLHttpRequest: true
                 });
-                gitlab.users.current().then(function (response) {
+                gitlab.Users.current().then(function (response) {
                     if (response) deferred.resolve(true);
                     else deferred.resolve(false);
                 }, function (error) {

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -124,7 +124,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: accessToken
+                token: accessToken,
+                useXMLHttpRequest: true
             });
 
             if (giturl.parts.length < 2) {
@@ -280,7 +281,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: params.accessToken
+                token: params.accessToken,
+                useXMLHttpRequest: true
             });
 
             var commentBody = "was linked by [RTC Work Item " + params.workItem.object.id + "]" +
@@ -412,7 +414,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: accessToken
+                token: accessToken,
+                useXMLHttpRequest: true
             });
 
             if (giturl.parts.length < 2) {
@@ -489,7 +492,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: accessToken
+                token: accessToken,
+                useXMLHttpRequest: true
             });
 
             if (giturl.parts.length < 2) {
@@ -562,7 +566,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: accessToken
+                token: accessToken,
+                useXMLHttpRequest: true
             });
 
             if (giturl.parts.length < 2) {
@@ -661,7 +666,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: accessToken
+                token: accessToken,
+                useXMLHttpRequest: true
             });
 
             if (giturl.parts.length < 2) {
@@ -744,7 +750,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: accessToken
+                token: accessToken,
+                useXMLHttpRequest: true
             });
 
             // instead of checking for validity with the length of a path, it would be nice to
@@ -827,7 +834,8 @@ define([
 
             var gitlab = this.gitLabApi({
                 url: giturl.origin,
-                token: accessToken
+                token: accessToken,
+                useXMLHttpRequest: true
             });
 
             if (giturl.parts.length < 2) {
@@ -921,7 +929,8 @@ define([
                 // Check access token with GitLab
                 var gitlab = this.gitLabApi({
                     url: this._getOriginFromUrlObject(gitRepositoryUrl),
-                    token: accessToken
+                    token: accessToken,
+                    useXMLHttpRequest: true
                 });
                 gitlab.users.current().then(function (response) {
                     if (response) deferred.resolve(true);

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -145,7 +145,7 @@ define([
                     var renderedTemplate = new TemplateService()
                         .renderTemplateWithWorkItem(templateString, workItem);
 
-                    gitlab.projects.issues.create(giturl.joined, {
+                    gitlab.Issues.create(giturl.joined, {
                         title: workItem.object.attributes.summary.content,
                         description: renderedTemplate,
                         labels: tags
@@ -164,7 +164,7 @@ define([
             var deferred = new Deferred();
             var filePath = ".gitlab/issue_templates/" + this.issueTemplateName;
 
-            gitlab.projects.repository.files.showRaw(projectId, filePath, "master").then(function (response) {
+            gitlab.RepositoryFiles.showRaw(projectId, filePath, "master").then(function (response) {
                 deferred.resolve(response);
             }, function (error) {
                 deferred.reject("Couldn't get the issue template from GitLab. Error: " + (error.message || error));

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -122,7 +122,7 @@ define([
             tags = (tags.length) ? tags + ", " : tags;
             tags += "from-rtc-work-item";
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: accessToken,
                 useXMLHttpRequest: true
@@ -279,7 +279,7 @@ define([
             var deferredArray = [];
             var giturl = this._createUrlInformation(params.selectedGitRepository.url);
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: params.accessToken,
                 useXMLHttpRequest: true
@@ -412,7 +412,7 @@ define([
             var deferred = new Deferred();
             var giturl = this._createUrlInformation(selectedGitRepository.url);
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: accessToken,
                 useXMLHttpRequest: true
@@ -490,7 +490,7 @@ define([
             var deferred = new Deferred();
             var giturl = this._createUrlInformation(selectedGitRepository.url);
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: accessToken,
                 useXMLHttpRequest: true
@@ -564,7 +564,7 @@ define([
             var deferred = new Deferred();
             var giturl = this._createUrlInformation(selectedGitRepository.url);
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: accessToken,
                 useXMLHttpRequest: true
@@ -664,7 +664,7 @@ define([
             var giturl = this._createUrlInformation(selectedGitRepository.url);
             var deferred = new Deferred();
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: accessToken,
                 useXMLHttpRequest: true
@@ -748,7 +748,7 @@ define([
             var giturl = this._createUrlInformation(selectedGitRepository.url);
             var deferred = new Deferred();
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: accessToken,
                 useXMLHttpRequest: true
@@ -832,7 +832,7 @@ define([
             var giturl = this._createUrlInformation(selectedGitRepository.url);
             var deferred = new Deferred();
 
-            var gitlab = this.gitLabApi({
+            var gitlab = new this.gitLabApi({
                 url: giturl.origin,
                 token: accessToken,
                 useXMLHttpRequest: true
@@ -927,7 +927,7 @@ define([
                 });
             } else if (gitHost === this.gitLabString) {
                 // Check access token with GitLab
-                var gitlab = this.gitLabApi({
+                var gitlab = new this.gitLabApi({
                     url: this._getOriginFromUrlObject(gitRepositoryUrl),
                     token: accessToken,
                     useXMLHttpRequest: true

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -673,7 +673,7 @@ define([
             if (giturl.parts.length < 2) {
                 deferred.reject("Invalid repository URL.");
             } else {
-                gitlab.projects.repository.commits.all(giturl.joined, {
+                gitlab.Commits.all(giturl.joined, {
                     max_pages: 1,
                     per_page: 100
                 }).then(function (response) {

--- a/resources/ui/widget/js/RestServices/GitRestService.js
+++ b/resources/ui/widget/js/RestServices/GitRestService.js
@@ -322,7 +322,7 @@ define([
         addBackLinksToGitLabCommits: function (gitlab, path, sha, commentBody) {
             var deferred = new Deferred();
 
-            gitlab.projects.repository.commits.comments.create(path, sha, commentBody).then(function (response) {
+            gitlab.Commits.createComment(path, sha, commentBody).then(function (response) {
                 deferred.resolve(response);
             }, function (error) {
                 deferred.reject("Couldn't add a comment to the GitLab commit. Error: " + (error.error.message || error.error));
@@ -334,7 +334,7 @@ define([
         addBackLinksToGitLabIssues: function (gitlab, path, id, commentBody) {
             var deferred = new Deferred();
 
-            gitlab.projects.issues.notes.create(path, id, {
+            gitlab.IssueNotes.create(path, id, {
                 body: commentBody
             }).then(function (response) {
                 deferred.resolve(response);
@@ -348,7 +348,7 @@ define([
         addBackLinksToGitLabRequests: function (gitlab, path, id, commentBody) {
             var deferred = new Deferred();
 
-            gitlab.projects.mergeRequests.notes.create(path, id, {
+            gitlab.MergeRequestNotes.create(path, id, {
                 body: commentBody
             }).then(function (response) {
                 deferred.resolve(response);

--- a/resources/ui/widget/js/RestServices/JazzRestService.js
+++ b/resources/ui/widget/js/RestServices/JazzRestService.js
@@ -2,8 +2,9 @@ define([
     "dojo/_base/declare",
     "dojo/_base/array",
     "dojo/json",
+    "dojo/request/xhr",
     "dojo/Deferred"
-], function (declare, array, json, Deferred) {
+], function (declare, array, json, xhr, Deferred) {
     var _instance = null;
     var JazzRestService = declare(null, {
         commitLinkEncoder: null,
@@ -210,11 +211,13 @@ define([
         getAccessTokenByHost: function (hostUrl) {
             var deferred = new Deferred();
 
-            jazz.client.xhrGet({
-                url: this.personalTokenServiceUrl + "?key=" + hostUrl,
+            xhr.get(this.personalTokenServiceUrl, {
+                query: {
+                    key: hostUrl
+                },
                 handleAs: "json",
                 headers: {
-                    "accept": "application/json"
+                    "Accept": "application/json"
                 }
             }).then(function (response) {
                 deferred.resolve(response.token ? response.token : null);
@@ -233,9 +236,8 @@ define([
 
         // Saves the specified access token using the specified host
         saveAccessTokenByHost: function (hostUrl, accessToken) {
-            return jazz.client.xhrPost({
-                url: this.personalTokenServiceUrl,
-                postData: json.stringify({
+            return xhr.post(this.personalTokenServiceUrl, {
+                data: json.stringify({
                     key: hostUrl,
                     token: accessToken
                 }),
@@ -248,15 +250,14 @@ define([
         // Gets the Jazz user id. This is usually the email address.
         // Returns null if not found or on error.
         getCurrentUserId: function () {
-            return jazz.client.xhrGet({
-                url: this.currentUserUrl,
+            return xhr.get(this.currentUserUrl, {
                 handleAs: "json",
                 headers: {
                     "Accept": "application/json"
                 }
             }).then(function (response) {
                 return response.userId ? response.userId : null;
-            }, function (error){
+            }, function (error) {
                 return null;
             });
         },
@@ -267,16 +268,12 @@ define([
         // will be empty if there was an error.
         getAllRegisteredGitRepositoriesForProjectArea: function (projectAreaId) {
             var self = this;
-
-            var parameters = new URLSearchParams();
-            parameters.append("findRecursively", true);
-            parameters.append("ownerItemIds", projectAreaId);
-            parameters.append("populateProcessOwner", false);
-
-            var url = this.allRegisteredGitRepositoriesUrl + "?" + parameters.toString();
-
-            return jazz.client.xhrGet({
-                url: url,
+            return xhr.get(this.allRegisteredGitRepositoriesUrl, {
+                query: {
+                    findRecursively: "true",
+                    ownerItemIds: projectAreaId,
+                    populateProcessOwner: "false"
+                },
                 handleAs: "json",
                 headers: {
                     "Accept": "text/json"

--- a/resources/ui/widget/js/RestServices/JazzRestService.js
+++ b/resources/ui/widget/js/RestServices/JazzRestService.js
@@ -143,7 +143,7 @@ define([
                             artifactLinkTypeContainer.linkDTOs.push({
                                 _isNew: true,
                                 comment: request.title,
-                                url: self._createRichHoverUrl(request)
+                                url: request.linkUrl
                             });
                         } else {
                             artifactLinkTypeContainer.linkDTOs.push({
@@ -356,6 +356,7 @@ define([
         },
 
         // TODO: This needs some cleaning up...
+        // Keeping this even though it's no longer used. Might still be useful in the future.
         _createRichHoverUrl: function(artifact) {
             return this.richHoverServiceUrl + "/" + artifact.service +
                 "/" + new URL(artifact.webUrl).hostname +

--- a/src/RtcGitConnectorModules.js
+++ b/src/RtcGitConnectorModules.js
@@ -51,7 +51,7 @@ export const ClipboardJS = require('clipboard/dist/clipboard.min');
 export const GitHubApi = require('@octokit/rest');
 
 // GitLab API client library
-export const GitLabApi = require('node-gitlab-api');
+export const GitLabApi = require('gitlab');
 
 // Fontawesome fonts
 export const FontAwesome = require('@fortawesome/fontawesome');

--- a/src/RtcGitConnectorModules.js
+++ b/src/RtcGitConnectorModules.js
@@ -51,7 +51,7 @@ export const ClipboardJS = require('clipboard/dist/clipboard.min');
 export const GitHubApi = require('@octokit/rest');
 
 // GitLab API client library
-export const GitLabApi = require('gitlab');
+export const GitLabApi = require('gitlab/dist/es5').default;
 
 // Fontawesome fonts
 export const FontAwesome = require('@fortawesome/fontawesome');


### PR DESCRIPTION
This switches to using the latest version of the [node-gitlab](https://github.com/jdalrymple/node-gitlab) api library (v3.5.0 at the time of writing).

All API calls have been adjusted to the new syntax and have been tested to be working correctly.

The usage of the client jazz proxy has been completely removed. This fixes the issues that it was causing (query parameters were not being passed to the API correctly). The removal of the client proxy was done after sufficient investigation together with @SBI- which revealed that the proxy was never needed in the first place.

This resolves issue #17 