### PR TITLE
Reorder lists to link

### DIFF
--- a/resources/ui/widget/js/MainLayout.js
+++ b/resources/ui/widget/js/MainLayout.js
@@ -276,8 +276,8 @@ define([
             this.mainDataStore.selectedRepositorySettings.watch("accessToken", function (name, oldValue, value) {
                 // Set the default link type if the access token is not null
                 if (value) {
-                    // Set the link type to commit (as default)
-                    self.mainDataStore.selectedRepositorySettings.set("linkType", "COMMIT");
+                    // Set the link type to issue (as default)
+                    self.mainDataStore.selectedRepositorySettings.set("linkType", "ISSUE");
                 }
             });
         },

--- a/resources/ui/widget/js/SelectLinkType.js
+++ b/resources/ui/widget/js/SelectLinkType.js
@@ -86,28 +86,6 @@ define([
                     self.showViewAndSelectWidget(value);
                 }
 
-                if (!self.mainDataStore.selectedRepositorySettings.get("commitsLoaded") &&
-                        !self.mainDataStore.selectedRepositorySettings.get("commitsLoading")) {
-                    // Set the commitsLoading to true to prevent multiple requests
-                    self.mainDataStore.selectedRepositorySettings.set("commitsLoading", true);
-
-                    // Get commits from host if not already loaded
-                    self.gitRestService.getRecentCommits(selectedRepository, gitHost, accessToken,
-                        self.jazzRestService.getGitCommitLinksFromWorkItem(self.mainDataStore.workItem)).then(function (commits) {
-                        // Set the list in the store and set commitsLoaded to true.
-                        // Clear the list first just incase the function is run multiple times due to slow loading
-                        self.mainDataStore.selectedRepositoryData.commits
-                            .splice(0, self.mainDataStore.selectedRepositoryData.commits.length);
-                        self.mainDataStore.selectedRepositoryData.commits
-                            .push.apply(self.mainDataStore.selectedRepositoryData.commits, commits);
-                        self.mainDataStore.selectedRepositorySettings.set("commitsLoaded", true);
-                        self.mainDataStore.selectedRepositorySettings.set("commitsLoading", false);
-                    }, function (error) {
-                        self.mainDataStore.selectedRepositorySettings.set("commitsLoadError", error || "Unknown Error");
-                        self.showLoadingDataError(error);
-                    });
-                }
-
                 if (!self.mainDataStore.selectedRepositorySettings.get("issuesLoaded") &&
                         !self.mainDataStore.selectedRepositorySettings.get("issuesLoading")) {
                     // Set the issuesLoading to true to prevent multiple requests
@@ -148,6 +126,28 @@ define([
                         self.mainDataStore.selectedRepositorySettings.set("requestsLoading", false);
                     }, function (error) {
                         self.mainDataStore.selectedRepositorySettings.set("requestsLoadError", error || "Unknown Error");
+                        self.showLoadingDataError(error);
+                    });
+                }
+
+                if (!self.mainDataStore.selectedRepositorySettings.get("commitsLoaded") &&
+                        !self.mainDataStore.selectedRepositorySettings.get("commitsLoading")) {
+                    // Set the commitsLoading to true to prevent multiple requests
+                    self.mainDataStore.selectedRepositorySettings.set("commitsLoading", true);
+
+                    // Get commits from host if not already loaded
+                    self.gitRestService.getRecentCommits(selectedRepository, gitHost, accessToken,
+                        self.jazzRestService.getGitCommitLinksFromWorkItem(self.mainDataStore.workItem)).then(function (commits) {
+                        // Set the list in the store and set commitsLoaded to true.
+                        // Clear the list first just incase the function is run multiple times due to slow loading
+                        self.mainDataStore.selectedRepositoryData.commits
+                            .splice(0, self.mainDataStore.selectedRepositoryData.commits.length);
+                        self.mainDataStore.selectedRepositoryData.commits
+                            .push.apply(self.mainDataStore.selectedRepositoryData.commits, commits);
+                        self.mainDataStore.selectedRepositorySettings.set("commitsLoaded", true);
+                        self.mainDataStore.selectedRepositorySettings.set("commitsLoading", false);
+                    }, function (error) {
+                        self.mainDataStore.selectedRepositorySettings.set("commitsLoadError", error || "Unknown Error");
                         self.showLoadingDataError(error);
                     });
                 }

--- a/resources/ui/widget/templates/SelectLinkType.html
+++ b/resources/ui/widget/templates/SelectLinkType.html
@@ -1,18 +1,13 @@
 <div>
     <div id="rtcGitConnectorSelectLinkTypeContainer" style="display: none;">
         <div class="rtcGitConnectorSelectLinkType">
-            <div class="linkTypeItem" data-link-type="COMMIT">Commits</div>
             <div class="linkTypeItem" data-link-type="ISSUE">Issues</div>
             <div class="linkTypeItem" data-link-type="REQUEST">Requests</div>
+            <div class="linkTypeItem" data-link-type="COMMIT">Commits</div>
         </div>
     </div>
 
     <p id="errorLoadingDataFromHostContainer" class="rtcGitConnectorMessage rtcGitConnectorMessageError" style="display: none;"></p>
-
-    <div class="rtcGitConnectorViewAndSelectContainer" data-link-type="COMMIT" style="display: none;">
-        <div data-dojo-attach-point="viewAndSelectCommits"
-            data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectCommits"></div>
-    </div>
 
     <div class="rtcGitConnectorViewAndSelectContainer" data-link-type="ISSUE" style="display: none;">
         <div data-dojo-attach-point="viewAndSelectIssues"
@@ -24,11 +19,12 @@
             data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectRequests"></div>
     </div>
 
+    <div class="rtcGitConnectorViewAndSelectContainer" data-link-type="COMMIT" style="display: none;">
+        <div data-dojo-attach-point="viewAndSelectCommits"
+            data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectCommits"></div>
+    </div>
+
     <div class="rtcGitConnectorListsToLinkContainer">
-        <div id="rtcGitConnectorCommitsListToLink" class="rtcGitConnectorListToLink">
-            <div data-dojo-attach-point="viewCommitsToLink"
-                data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewCommitsToLink"></div>
-        </div>
         <div id="rtcGitConnectorIssuesListToLink" class="rtcGitConnectorListToLink">
             <div data-dojo-attach-point="viewIssuesToLink"
                 data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewIssuesToLink"></div>
@@ -36,6 +32,10 @@
         <div id="rtcGitConnectorRequestsListToLink" class="rtcGitConnectorListToLink">
             <div data-dojo-attach-point="viewRequestsToLink"
                 data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewRequestsToLink"></div>
+        </div>
+        <div id="rtcGitConnectorCommitsListToLink" class="rtcGitConnectorListToLink">
+            <div data-dojo-attach-point="viewCommitsToLink"
+                data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewCommitsToLink"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Changes the order from "Commits, Issues, Merge Requests" to "Issues, Merge Requests, Commits".

Commits are always displayed and loaded last. This is because the more common use cases involve issues and merge requests more than commits.