### PR TITLE
Frontend version timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     },
     "devDependencies": {
         "jazz-update-site-webpack-plugin": "^0.4.1",
+        "moment": "^2.22.2",
+        "string-replace-loader": "^2.1.1",
         "uglifyjs-webpack-plugin": "^1.1.4",
         "webpack": "^3.6.0"
     },

--- a/src/RtcGitConnectorModules.js
+++ b/src/RtcGitConnectorModules.js
@@ -63,6 +63,9 @@ const FaLink = require('@fortawesome/fontawesome-free-solid/faLink');
 const FaTrash = require('@fortawesome/fontawesome-free-solid/faTrash');
 const FaSpinner = require('@fortawesome/fontawesome-free-solid/faSpinner');
 
+// Build version
+export const buildVersion = '__BUILD_VERSION__';
+
 // Adding the entire solid library doesn't seem to work in the frontend.
 // So we have no other choice than adding them one by one.
 FontAwesome.library.add(FaCheck);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,12 @@
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const moment = require('moment');
 const packageJson = require('./package.json');
 const JazzUpdateSitePlugin = require('jazz-update-site-webpack-plugin');
 
 module.exports = (env) => {
-    const version = (typeof env !== 'undefined' && env.buildUUID) || packageJson.version;
+    const now = new Date();
+    const timestamp = moment().format('[-]YYYYMMDD-HHMM');
+    const version = (typeof env !== 'undefined' && packageJson.version + "-" + env.buildUUID) || packageJson.version + timestamp;
     const config = {
         node : {
             fs : 'empty',
@@ -19,6 +22,21 @@ module.exports = (env) => {
             libraryTarget: 'var',
             library: 'com_siemens_bt_jazz_rtcgitconnector_modules',
             filename: './resources/dist/modules-bundle.js',
+        },
+
+        module: {
+            rules: [
+                {
+                    test: /RtcGitConnectorModules\.js$/,
+                    loader: 'string-replace-loader',
+                    options: {
+                        search: '__BUILD_VERSION__',
+                        replace: version,
+                        flags: 'i',
+                        strict: true
+                    }
+                }
+            ]
         },
 
         plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const JazzUpdateSitePlugin = require('jazz-update-site-webpack-plugin');
 
 module.exports = (env) => {
     const now = new Date();
-    const timestamp = moment().format('[-]YYYYMMDD-HHMM');
+    const timestamp = moment().format('[_]YYYYMMDD[-]HHMM');
     const version = (typeof env !== 'undefined' && packageJson.version + "-" + env.buildUUID) || packageJson.version + timestamp;
     const config = {
         node : {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,9 +4,8 @@ const packageJson = require('./package.json');
 const JazzUpdateSitePlugin = require('jazz-update-site-webpack-plugin');
 
 module.exports = (env) => {
-    const now = new Date();
     const timestamp = moment().format('[_]YYYYMMDD[-]HHMM');
-    const version = (typeof env !== 'undefined' && packageJson.version + "-" + env.buildUUID) || packageJson.version + timestamp;
+    const version = (typeof env !== 'undefined' && packageJson.version + "_" + env.buildUUID) || packageJson.version + timestamp;
     const config = {
         node : {
             fs : 'empty',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,8 @@ const packageJson = require('./package.json');
 const JazzUpdateSitePlugin = require('jazz-update-site-webpack-plugin');
 
 module.exports = (env) => {
-    const timestamp = moment().format('[_]YYYYMMDD[-]HHMM');
-    const version = (typeof env !== 'undefined' && packageJson.version + "_" + env.buildUUID) || packageJson.version + timestamp;
+    const timestamp = moment().format('[_]YYYYMMDD[-]HHmm');
+    const version = (typeof env !== 'undefined' && (packageJson.version + "_" + env.buildUUID)) || packageJson.version + timestamp;
     const config = {
         node : {
             fs : 'empty',


### PR DESCRIPTION
This change exposes the build version + timestamp at runtime. It's one of many ways to solve this problem, and certainly not one that is compatible with all our plugins. However, it will work fine with this plugin, as we use webpack for dependencies anyway.

Maybe we can derive a general solution from this later on, and include it in one of the jazz npm plugins.