### PR TITLE
Add a dependency to the service in MANIFEST.MF

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,5 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Web
+Bundle-Name: RTC Git Connector
 Bundle-SymbolicName: com.siemens.bt.jazz.workitemeditor.rtcGitConnector;singleton:=true
 Bundle-Version: 2.3.1.qualifier
+Bundle-Vendor: Siemens Building Technologies
+Bundle-Localization: plugin
+Require-Bundle: org.jazzcommunity.GitConnectorService;bundle-version="1.8.3"

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -5,4 +5,5 @@ Bundle-SymbolicName: com.siemens.bt.jazz.workitemeditor.rtcGitConnector;singleto
 Bundle-Version: 2.3.1.qualifier
 Bundle-Vendor: Siemens Building Technologies
 Bundle-Localization: plugin
-Require-Bundle: org.jazzcommunity.GitConnectorService;bundle-version="1.8.3"
+Require-Bundle: org.jazzcommunity.GitConnectorService;bundle-version="1.8.3",
+    com.siemens.bt.jazz.services.PersonalTokenService;bundle-version="1.0.1"


### PR DESCRIPTION
Add a dependency to the GitConnectorService and the PersonalTokenService as described in issue #18 

This should help prevent incompatible versions from being deployed together.

