### PR TITLE
Improve visibility of the link buttons

### DIFF
--- a/resources/ui/widget/components/ListItem/ListItem.css
+++ b/resources/ui/widget/components/ListItem/ListItem.css
@@ -35,6 +35,15 @@
     font-size: 1.5em;
     text-align: center;
     cursor: pointer;
+    transition: transform 500ms;
+}
+
+.rtcGitConnectorViewAndSelectListItem:hover .rtcGitConnectorViewAndSelectListItemButton {
+    transform: scale(1.5) rotate(360deg);
+}
+
+.rtcGitConnectorViewAndSelectListItem.selected .rtcGitConnectorViewAndSelectListItemButton {
+    transform: scale(1.5) rotate(720deg);
 }
 
 .rtcGitConnectorViewAndSelectListItem.linkButton .rtcGitConnectorViewAndSelectListItemButton {
@@ -60,4 +69,5 @@
 .rtcGitConnectorViewAndSelectListItem.checkButton .rtcGitConnectorViewAndSelectListItemButton {
     color: #555;
     cursor: default;
+    transform: none;
 }

--- a/resources/ui/widget/components/ListItem/ListItem.css
+++ b/resources/ui/widget/components/ListItem/ListItem.css
@@ -38,10 +38,12 @@
     transition: transform 500ms;
 }
 
+/* Make the list item button grow and spin once when hovering over the list item. */
 .rtcGitConnectorViewAndSelectListItem:hover .rtcGitConnectorViewAndSelectListItemButton {
     transform: scale(1.5) rotate(360deg);
 }
 
+/* Make the list item button spin once again when the list item is selected (attract attention). */
 .rtcGitConnectorViewAndSelectListItem.selected .rtcGitConnectorViewAndSelectListItemButton {
     transform: scale(1.5) rotate(720deg);
 }
@@ -66,6 +68,7 @@
     opacity: 0.6;
 }
 
+/* Make the "checkButton" have a normal cursor and no animations (disabled). */
 .rtcGitConnectorViewAndSelectListItem.checkButton .rtcGitConnectorViewAndSelectListItemButton {
     color: #555;
     cursor: default;

--- a/resources/ui/widget/components/ListItem/ListItem.css
+++ b/resources/ui/widget/components/ListItem/ListItem.css
@@ -30,7 +30,7 @@
 
 .rtcGitConnectorViewAndSelectListItemButton {
     width: 2em;
-    height: 100%;
+    height: 1em;
     margin: auto .3em;
     font-size: 1.5em;
     text-align: center;

--- a/resources/ui/widget/components/MainLayout/MainLayout.html
+++ b/resources/ui/widget/components/MainLayout/MainLayout.html
@@ -28,8 +28,8 @@
     <br />
 
     <div class="rtcGitConnectorActionButtons">
-        <button id="rtcGitConnectorSaveButton" class="primary-button" type="button">Save</button>
-        <button id="rtcGitConnectorSaveAndCloseButton" class="primary-button" type="button">Save and Close</button>
+        <button id="rtcGitConnectorSaveButton" class="primary-button" type="button" disabled>Save</button>
+        <button id="rtcGitConnectorSaveAndCloseButton" class="primary-button" type="button" disabled>Save and Close</button>
         <button id="rtcGitConnectorCancelButton" class="secondary-button" type="button">Cancel</button>
     </div>
 

--- a/resources/ui/widget/components/MainLayout/MainLayout.js
+++ b/resources/ui/widget/components/MainLayout/MainLayout.js
@@ -296,18 +296,22 @@ define([
                 }
             });
 
+            // Encapsulate scope for _listToLinkChanged
             var listToLinkChanged = function () {
                 self._listToLinkChanged();
             };
 
+            // Run listToLinkChanged when any of the lists of items to link change
             this.mainDataStore.selectedRepositoryData.commitsToLink.watchElements(listToLinkChanged);
             this.mainDataStore.selectedRepositoryData.issuesToLink.watchElements(listToLinkChanged);
             this.mainDataStore.selectedRepositoryData.requestsToLink.watchElements(listToLinkChanged);
 
+            // Encapsulate scope for _itemsLoadedChanged
             var itemsLoadedChanged = function () {
                 self._itemsLoadedChanged();
             };
 
+            // Run itemsLoadedChanged when the loaded status of any of the lists of items changes
             this.mainDataStore.selectedRepositorySettings.watch("issuesLoaded", itemsLoadedChanged);
             this.mainDataStore.selectedRepositorySettings.watch("requestsLoaded", itemsLoadedChanged);
             this.mainDataStore.selectedRepositorySettings.watch("commitsLoaded", itemsLoadedChanged);
@@ -479,7 +483,9 @@ define([
         _itemsLoadedChanged: function () {
             var showSelectItemMessage = false;
 
+            // Check if all lists are loaded and there aren't any items to link
             if (this._allListsLoaded() && !this._anyItemsToLink()) {
+                // Show the select item message
                 showSelectItemMessage = true;
             }
 
@@ -488,7 +494,10 @@ define([
 
         // Set the enabled/disabled state for both save buttons (true = enabled)
         _setSaveButtonsState: function (enabled) {
+            // Check if all lists are loaded
+            // (don't show the select item message before that)
             if (this._allListsLoaded()) {
+                // Also show/hide the select item message if all links are loaded
                 this._showSelectItemMessage(!enabled);
             }
 

--- a/resources/ui/widget/components/MainLayout/MainLayout.js
+++ b/resources/ui/widget/components/MainLayout/MainLayout.js
@@ -297,6 +297,14 @@ define([
                     self.mainDataStore.selectedRepositorySettings.set("linkType", "ISSUE");
                 }
             });
+
+            var listToLinkChanged = function () {
+                self._listToLinkChanged();
+            };
+
+            this.mainDataStore.selectedRepositoryData.commitsToLink.watchElements(listToLinkChanged);
+            this.mainDataStore.selectedRepositoryData.issuesToLink.watchElements(listToLinkChanged);
+            this.mainDataStore.selectedRepositoryData.requestsToLink.watchElements(listToLinkChanged);
         },
 
         // Find out if the selected git repository is hosted on GitHub, GitLab, or neither of the two
@@ -445,6 +453,28 @@ define([
             } else {
                 mainDialog.hide();
             }
+        },
+
+        // Run whenever a list of items to link has changed
+        // Will enable / disable the save buttons
+        _listToLinkChanged: function () {
+            var buttonsEnabled = false;
+
+            // Check if any of the lists contain data
+            if (this.mainDataStore.selectedRepositoryData.commitsToLink.length > 0 ||
+                this.mainDataStore.selectedRepositoryData.issuesToLink.length > 0 ||
+                this.mainDataStore.selectedRepositoryData.requestsToLink.length > 0) {
+                // Enable the save buttons
+                buttonsEnabled = true;
+            }
+
+            this._setSaveButtonsState(buttonsEnabled);
+        },
+
+        // Set the enabled/disabled state for both save buttons (true = enabled)
+        _setSaveButtonsState: function (enabled) {
+            dom.byId("rtcGitConnectorSaveButton").disabled = !enabled;
+            dom.byId("rtcGitConnectorSaveAndCloseButton").disabled = !enabled;
         }
     });
 });

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
@@ -1,4 +1,9 @@
 /* See: http://www.cssarrowplease.com/ */
+
+/*
+    Make the message div about the same width as a list item.
+    Add extra margin top so that there is space for the arrow.
+*/
 .rtcGitConnectorSelectItemMessage {
     position: relative;
     width: calc(50% - 35px);
@@ -7,6 +12,9 @@
     margin-left: 11px;
 }
 
+/*
+    Use before and after to create and position zero size elements in the same spot.
+*/
 .rtcGitConnectorSelectItemMessage::after, .rtcGitConnectorSelectItemMessage::before {
     position: absolute;
     bottom: 100%;
@@ -18,14 +26,31 @@
     pointer-events: none;
 }
 
+/*
+    Use the after element as the inner triangle.
+    Looks like an extension of the div.
+    The border width defines the height of the triangle.
+    The triangle is created by making only the bottom border visible.
+    Margin is used for positioning the tip of the triangle in the
+    center (should equal border width).
+*/
 .rtcGitConnectorSelectItemMessage::after {
     border-bottom-color: #d9edf7; /* backgroundColor */
     border-width: 15px; /* arrowHeight */
     margin-left: -15px;
 }
 
+/*
+    Use the before element as the outer triangle.
+    Looks like an extension of the border around the div.
+    The border width should use the formula commented below.
+    This is important when the div has a wider border, otherwise
+    the border on the triangle part will be too small.
+    Margin is used for positioning the tip of the triangle in the
+    center (should equal border width).
+*/
 .rtcGitConnectorSelectItemMessage::before {
     border-bottom-color: #31708f; /* borderColor */
-    border-width: 17px; /* Math.round(borderWidth * Math.sqrt(2)) */
+    border-width: 17px; /* afterBorderWidth + Math.round(divBorderWidth * Math.sqrt(2)) */
     margin-left: -17px;
 }

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
@@ -1,10 +1,28 @@
-.rtcGitConnectorSelectItemMessage:before {
+.rtcGitConnectorSelectItemMessage {
+    position: relative;
+    margin-top: 20px;
+    margin-bottom: 10px;
+}
+
+.rtcGitConnectorSelectItemMessage::after, .rtcGitConnectorSelectItemMessage::before {
     position: absolute;
-    top: 0;
-    left: 50px;
-    height: 10px;
-    width: 15px;
-    content: '';
-    background-color: #cacaca;
-    z-index: -1;
+    bottom: 100%;
+    left: 35px;
+    height: 0;
+    width: 0;
+    border: solid transparent;
+    content: " ";
+    pointer-events: none;
+}
+
+.rtcGitConnectorSelectItemMessage::after {
+    border-bottom-color: #d9edf7; /* backgroundColor */
+    border-width: 15px; /* arrowHeight */
+    margin-left: -15px;
+}
+
+.rtcGitConnectorSelectItemMessage::before {
+    border-bottom-color: #31708f; /* borderColor */
+    border-width: 17px; /* Math.round(borderWidth * Math.sqrt(2)) */
+    margin-left: -17px;
 }

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
@@ -1,0 +1,10 @@
+.rtcGitConnectorSelectItemMessage:before {
+    position: absolute;
+    top: 0;
+    left: 50px;
+    height: 10px;
+    width: 15px;
+    content: '';
+    background-color: #cacaca;
+    z-index: -1;
+}

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.css
@@ -1,13 +1,16 @@
+/* See: http://www.cssarrowplease.com/ */
 .rtcGitConnectorSelectItemMessage {
     position: relative;
+    width: calc(50% - 35px);
     margin-top: 20px;
     margin-bottom: 10px;
+    margin-left: 11px;
 }
 
 .rtcGitConnectorSelectItemMessage::after, .rtcGitConnectorSelectItemMessage::before {
     position: absolute;
     bottom: 100%;
-    left: 35px;
+    left: 25px;
     height: 0;
     width: 0;
     border: solid transparent;

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.html
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.html
@@ -1,5 +1,5 @@
 <div>
-    <div class="rtcGitConnectorSelectItemMessage"
+    <div class="rtcGitConnectorSelectItemMessage rtcGitConnectorMessage rtcGitConnectorMessageInfo"
         data-dojo-attach-point="messageNode">
     </div>
 </div>

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.html
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.html
@@ -1,0 +1,2 @@
+<div class="rtcGitConnectorViewAndSelectContainer rtcGitConnectorSelectItemMessage"  data-dojo-attach-point="messageNode">
+</div>

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.html
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.html
@@ -1,2 +1,5 @@
-<div class="rtcGitConnectorViewAndSelectContainer rtcGitConnectorSelectItemMessage"  data-dojo-attach-point="messageNode">
+<div>
+    <div class="rtcGitConnectorSelectItemMessage"
+        data-dojo-attach-point="messageNode">
+    </div>
 </div>

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.js
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.js
@@ -1,0 +1,25 @@
+define([
+    "dojo/_base/declare",
+    "dojo/dom-style",
+    "dijit/_WidgetBase",
+    "dijit/_TemplatedMixin",
+    "dojo/text!./SelectItemMessage.html",
+    "jazz/css!./SelectItemMessage.css"
+], function (declare, domStyle,
+    _WidgetBase, _TemplatedMixin,
+    template) {
+    return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.selectItemMessage",
+        [_WidgetBase, _TemplatedMixin,],
+    {
+        templateString: template,
+
+        hidden: true,
+        _setHiddenAttr: function (hidden) {
+            domStyle.set(this.domNode, "display", hidden ? "none" : "block");
+            this._set("hidden", hidden);
+        },
+
+        message: "Click the colorful icon on the left to select an item to be saved.",
+        _setMessageAttr: { node: "messageNode", type: "innerHTML" }
+    });
+});

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.js
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.js
@@ -15,7 +15,7 @@ define([
 
         hidden: true,
         _setHiddenAttr: function (hidden) {
-            domStyle.set(this.domNode, "display", hidden ? "none" : "block");
+            domStyle.set(this.messageNode, "display", hidden ? "none" : "block");
             this._set("hidden", hidden);
         },
 

--- a/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.js
+++ b/resources/ui/widget/components/SelectItemMessage/SelectItemMessage.js
@@ -13,12 +13,16 @@ define([
     {
         templateString: template,
 
+        // Hide the message by default
+        // Set to false to show the message
         hidden: true,
         _setHiddenAttr: function (hidden) {
             domStyle.set(this.messageNode, "display", hidden ? "none" : "block");
             this._set("hidden", hidden);
         },
 
+        // Define the default message to show
+        // Set to a different string to change the message
         message: "Click the colorful icon on the left to select an item to be saved.",
         _setMessageAttr: { node: "messageNode", type: "innerHTML" }
     });

--- a/resources/ui/widget/components/SelectLinkType/SelectLinkType.html
+++ b/resources/ui/widget/components/SelectLinkType/SelectLinkType.html
@@ -24,6 +24,9 @@
             data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectCommits"></div>
     </div>
 
+    <div data-dojo-attach-point="selectItemMessage"
+        data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.selectItemMessage"></div>
+
     <div data-dojo-attach-point="setNewWorkItemAttributes"
         data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemAttributes"></div>
 

--- a/resources/ui/widget/components/SelectLinkType/SelectLinkType.js
+++ b/resources/ui/widget/components/SelectLinkType/SelectLinkType.js
@@ -79,7 +79,7 @@ define([
                     return;
                 }
 
-                // Hide the hole widget if the linkType is null
+                // Hide the whole widget if the linkType is null
                 domStyle.set("rtcGitConnectorSelectLinkTypeContainer", "display", "block");
 
                 loadingError = self.mainDataStore.selectedRepositorySettings.get(value.toLowerCase() + "sLoadError");

--- a/resources/ui/widget/components/SelectLinkType/SelectLinkType.js
+++ b/resources/ui/widget/components/SelectLinkType/SelectLinkType.js
@@ -14,6 +14,7 @@ define([
     "../ViewCommitsToLink/ViewCommitsToLink",
     "../ViewIssuesToLink/ViewIssuesToLink",
     "../ViewRequestsToLink/ViewRequestsToLink",
+    "../SelectItemMessage/SelectItemMessage",
     "../SetNewWorkItemAttributes/SetNewWorkItemAttributes",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
@@ -22,7 +23,8 @@ define([
 ], function (declare, dom, domClass, domStyle, on, query,
     MainDataStore, JazzRestService, GitRestService,
     ViewAndSelectCommits, ViewAndSelectIssues, ViewAndSelectRequests,
-    ViewCommitsToLink, ViewIssuesToLink, ViewRequestsToLink, SetNewWorkItemAttributes,
+    ViewCommitsToLink, ViewIssuesToLink, ViewRequestsToLink,
+    SelectItemMessage, SetNewWorkItemAttributes,
     _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.selectLinkType",


### PR DESCRIPTION
Based on feedback from multiple users, parts of the UI aren't self-explanatory for new users.

They click on an item to view the details and then click save without first clicking the link button. The widget doesn't do anything in this case (since the link button hasn't been pressed) so it appears to not work.

This pull request introduces multiple improvements to fix this problem.
- First of all, the save buttons are disabled so long as there is nothing selected to save. This already will fix the main issue.
- Additionally, an animation has been added to the button when hovering or selecting an item. This should help to make it more visible.
- Last but not least, a message is shown when the user hasn't selected anything to link. The message has an arrow pointing towards the button that they need to press.

Fixes #32 
