### PR TITLE
Use just-handlebars-helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3894,6 +3894,11 @@
                 "verror": "1.10.0"
             }
         },
+        "just-handlebars-helpers": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/just-handlebars-helpers/-/just-handlebars-helpers-1.0.14.tgz",
+            "integrity": "sha1-PNQNJPJrNxwmFHLN1louvP4k3lI="
+        },
         "kind-of": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "gitlab": "^3.10.1",
         "gzip-js": "^0.3.2",
         "handlebars": "^4.0.11",
+        "just-handlebars-helpers": "^1.0.14",
         "turndown": "^4.0.2"
     },
     "devDependencies": {

--- a/resources/ui/widget/services/TemplateService.js
+++ b/resources/ui/widget/services/TemplateService.js
@@ -7,10 +7,12 @@ define([
 
         constructor: function () {
             this.handlebars = com_siemens_bt_jazz_rtcgitconnector_modules.Handlebars;
+            this.justHandlebarsHelpers = com_siemens_bt_jazz_rtcgitconnector_modules.JustHandlebarsHelpers;
             this.turndownService = new com_siemens_bt_jazz_rtcgitconnector_modules.TurndownService();
 
             this._doNotEscapeMarkdown();
             this._registerHtmlToMarkdownHelper();
+            this._registerJustHandlebarsHelpers();
         },
 
         renderTemplateWithWorkItem: function (templateString, workItem) {
@@ -35,6 +37,11 @@ define([
                 // For the Markdown formatting to work correctly, these need to be normal spaces.
                 return inputString ? self.turndownService.turndown(inputString.replace(/&nbsp;/g, ' ')) : '';
             });
+        },
+
+        _registerJustHandlebarsHelpers: function () {
+            // Register all the helpers in the just-handlebars-helpers package
+            this.justHandlebarsHelpers.registerHelpers(this.handlebars);
         }
     });
 });

--- a/src/RtcGitConnectorModules.js
+++ b/src/RtcGitConnectorModules.js
@@ -39,7 +39,10 @@ export function encoder () {
 }
 
 // Handlebars for the browser (templating)
-export const Handlebars = require('handlebars/dist/handlebars');
+export const Handlebars = require('handlebars/dist/handlebars.min.js');
+
+// Helpers for using in Handlebars templates
+export const JustHandlebarsHelpers = require('just-handlebars-helpers/dist/h.min.js');
 
 // Turndown service for the browser (html to markdown)
 export const TurndownService = require('turndown/lib/turndown.browser.umd');


### PR DESCRIPTION
Adds [just-handlebars-helpers](https://github.com/leapfrogtechnology/just-handlebars-helpers) for using when creating git issues from an issue template.

This enables you to use any of the the helper functions defined in the just-handlebars-helpers package when writing custom issue templates.