### PR TITLE
Allow the user to set tags for new work items created from git issues

### DIFF
--- a/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.js
+++ b/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.js
@@ -17,7 +17,7 @@ define([
         templateString: template,
         mainDataStore: null,
         hasOverview: false,
-        attributesToShow: ["category", "owner", "target", "foundIn"],
+        attributesToShow: ["category", "owner", "target", "foundIn", "internalTags"],
 
         visible: false,
         _setVisibleAttr: function (visible) {
@@ -51,7 +51,7 @@ define([
         },
 
         // Create a work item editor with only the specified attributes.
-        // ["category", "owner", "target", "foundIn"]
+        // ["category", "owner", "target", "foundIn", "internalTags"]
         // If the attribute is not available for the current work item presentation
         // it will just be left out.
         createOverview: function () {
@@ -145,6 +145,7 @@ define([
 
         // Only keep the section presentations for the specified attributes
         _filterSectionPresentationsByAttributes: function (section, attributes) {
+            console.log("section: ", section);
             section.presentations = section.presentations.filter(function (presentation) {
                 return attributes.some(function (attribute) {
                     return attribute === presentation.attributeId;


### PR DESCRIPTION
This adds the option for the user to specify tags that will be set on all new work items when creating work items from git issues.

The specified tags will be added to the "from-git-issue" tag and as well as any labels defined on the git issues (existing functionality).