### PR TITLE
Allow the user to set the parent work item for all new work items created from git issues

### DIFF
--- a/resources/ui/widget/components/RtcGitConnector/RtcGitConnector.css
+++ b/resources/ui/widget/components/RtcGitConnector/RtcGitConnector.css
@@ -83,10 +83,10 @@
     font-size: 1em;
     font-weight: bold;
     color: #666666;
-    width: 200px;
 }
 
 .rtcGitConnectorSelectRegisteredGitRepository .rtcGitConnectorLabelText {
+    width: 200px;
     margin-top: auto;
     margin-bottom: auto;
 }

--- a/resources/ui/widget/components/SelectLinkType/SelectLinkType.html
+++ b/resources/ui/widget/components/SelectLinkType/SelectLinkType.html
@@ -27,8 +27,8 @@
     <div data-dojo-attach-point="selectItemMessage"
         data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.selectItemMessage"></div>
 
-    <div data-dojo-attach-point="setNewWorkItemAttributes"
-        data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemAttributes"></div>
+    <div data-dojo-attach-point="setNewWorkItemValues"
+        data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemValues"></div>
 
     <div class="rtcGitConnectorListsToLinkContainer">
         <div id="rtcGitConnectorIssuesListToLink" class="rtcGitConnectorListToLink">

--- a/resources/ui/widget/components/SelectLinkType/SelectLinkType.js
+++ b/resources/ui/widget/components/SelectLinkType/SelectLinkType.js
@@ -15,7 +15,7 @@ define([
     "../ViewIssuesToLink/ViewIssuesToLink",
     "../ViewRequestsToLink/ViewRequestsToLink",
     "../SelectItemMessage/SelectItemMessage",
-    "../SetNewWorkItemAttributes/SetNewWorkItemAttributes",
+    "../SetNewWorkItemValues/SetNewWorkItemValues",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
@@ -24,7 +24,7 @@ define([
     MainDataStore, JazzRestService, GitRestService,
     ViewAndSelectCommits, ViewAndSelectIssues, ViewAndSelectRequests,
     ViewCommitsToLink, ViewIssuesToLink, ViewRequestsToLink,
-    SelectItemMessage, SetNewWorkItemAttributes,
+    SelectItemMessage, SetNewWorkItemValues,
     _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.selectLinkType",
@@ -48,7 +48,7 @@ define([
 
             if (this.mainDataStore.newWorkItemMode) {
                 this.onlyShowIssuesTab();
-                this.setNewWorkItemAttributes.startup();
+                this.setNewWorkItemValues.startup();
             } else {
                 this.viewAndSelectCommits.startup();
                 this.viewAndSelectRequests.startup();

--- a/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.html
+++ b/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.html
@@ -1,4 +1,4 @@
-<div style="display: none;">
+<div>
     <div id="rtcGitConnectorSetNewWorkItemAttributes" class="com-ibm-team-workitem">
         <div class="workItemEditor" data-dojo-attach-point="attributesContainer"></div>
     </div>

--- a/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.js
+++ b/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.js
@@ -145,7 +145,6 @@ define([
 
         // Only keep the section presentations for the specified attributes
         _filterSectionPresentationsByAttributes: function (section, attributes) {
-            console.log("section: ", section);
             section.presentations = section.presentations.filter(function (presentation) {
                 return attributes.some(function (attribute) {
                     return attribute === presentation.attributeId;

--- a/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.js
+++ b/resources/ui/widget/components/SetNewWorkItemAttributes/SetNewWorkItemAttributes.js
@@ -1,13 +1,12 @@
 define([
     "dojo/_base/declare",
     "dojo/_base/lang",
-    "dojo/dom-style",
     "../../services/MainDataStore",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dojo/text!./SetNewWorkItemAttributes.html",
     "jazz/css!./SetNewWorkItemAttributes.css"
-], function (declare, lang, domStyle,
+], function (declare, lang,
     MainDataStore,
     _WidgetBase, _TemplatedMixin,
     template) {
@@ -19,35 +18,16 @@ define([
         hasOverview: false,
         attributesToShow: ["category", "owner", "target", "foundIn", "internalTags"],
 
-        visible: false,
-        _setVisibleAttr: function (visible) {
-            domStyle.set(this.domNode, "display", visible ? "block" : "none");
-            this._set("visible", visible);
-        },
-
         constructor: function () {
             this.mainDataStore = MainDataStore.getInstance();
         },
 
-        startup: function () {
-            if (this.mainDataStore.newWorkItemMode) {
-                this.watchDataStore();
+        // Only create the overview once the show method is called
+        show: function () {
+            if (!this.hasOverview) {
+                this.hasOverview = true;
+                this.createOverview();
             }
-        },
-
-        watchDataStore: function () {
-            var self = this;
-
-            // Only show the attributes when the list of selected issues isn't empty
-            this.mainDataStore.selectedRepositoryData.issuesToLink.watchElements(function () {
-                var hasItems = self.mainDataStore.selectedRepositoryData.issuesToLink.length > 0;
-                self.set("visible", hasItems);
-
-                if (hasItems && !self.hasOverview) {
-                    self.hasOverview = true;
-                    self.createOverview();
-                }
-            });
         },
 
         // Create a work item editor with only the specified attributes.

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.css
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.css
@@ -1,0 +1,3 @@
+.setNewWorkItemLinksContainer {
+    padding-top: 0.5em;
+}

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
@@ -1,3 +1,6 @@
 <div>
-    <div data-dojo-attach-point="linksContainer"></div>
+    <div class="rtcGitConnectorViewAndSelectContainer">
+        <div class="rtcGitConnectorLabelText">Set the parent for the new work items</div>
+        <div data-dojo-attach-point="linksContainer"></div>
+    </div>
 </div>

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
@@ -1,5 +1,5 @@
 <div>
-    <div class="rtcGitConnectorViewAndSelectContainer">
+    <div class="viewItemsToLinkContainer">
         <div class="rtcGitConnectorLabelText">Set the parent for the new work items</div>
         <div data-dojo-attach-point="linksContainer"></div>
     </div>

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
@@ -1,0 +1,3 @@
+<div>
+    <div data-dojo-attach-point="linksContainer"></div>
+</div>

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.html
@@ -1,6 +1,6 @@
 <div>
     <div class="viewItemsToLinkContainer">
         <div class="rtcGitConnectorLabelText">Set the parent for the new work items</div>
-        <div data-dojo-attach-point="linksContainer"></div>
+        <div class="setNewWorkItemLinksContainer" data-dojo-attach-point="linksContainer"></div>
     </div>
 </div>

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
@@ -1,15 +1,18 @@
 define([
     "dojo/_base/declare",
-    "dojo/_base/lang",
+    "dojo/dom-construct",
     "../../services/MainDataStore",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dojo/text!./SetNewWorkItemLinks.html",
-    "jazz/css!./SetNewWorkItemLinks.css"
-], function (declare, lang,
+    "jazz/css!./SetNewWorkItemLinks.css",
+    "com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown"
+], function (declare, domConstruct,
     MainDataStore,
     _WidgetBase, _TemplatedMixin,
     template) {
+    var ActionDropdown = com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown;
+
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemLinks",
         [_WidgetBase, _TemplatedMixin,],
     {
@@ -30,8 +33,8 @@ define([
         },
 
         createPresentation: function () {
-            // create the presentation and add it to the view
-            this.linksContainer.innerHTML = "Links Presentation";
+            var actionsMenuDiv = domConstruct.create("div", null, this.linksContainer);
+            var actionsMenu = ActionDropdown.create({}, actionsMenuDiv);
         }
     });
 });

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
@@ -53,6 +53,8 @@ define([
             this.enabledEndpoints = new ArrayList();
             this.enabledEndpoints.add(WorkItemEndpoints.PARENT_WORK_ITEM);
 
+            this.enabledEndpoints.add(WorkItemEndpoints.DEPENDS_ON_WORK_ITEM);
+
             this.enabledEndpointsWithValues = new BindableList();
         },
 
@@ -88,9 +90,9 @@ define([
                 this._launchDialog(workingCopy, workItemReferences, chosenDescriptor);
             }));
 
-            domStyle.set(actionsMenu._view._dropdownElement, "float", "none");
-            domStyle.set(actionsMenu._view._dropdownElement, "border-right", "none");
-            domStyle.set(actionsMenu._view._dropdownArrow, "display", "none");
+            // domStyle.set(actionsMenu._view._dropdownElement, "float", "none");
+            // domStyle.set(actionsMenu._view._dropdownElement, "border-right", "none");
+            // domStyle.set(actionsMenu._view._dropdownArrow, "display", "none");
 
             // Links pres
             var listViewDiv = domConstruct.create("div", null, this.linksContainer);
@@ -116,7 +118,10 @@ define([
                 result.onListChanged().addListener(function (callbackArg) {
                     if (!JDojoX.isEqual(result, references) && callbackArg.type === 'remove') {
                         workItemReferences.remove(endpoint, callbackArg.elements[0]);
-                        self.enabledEndpointsWithValues.remove(endpoint);
+
+                        if (!workItemReferences.hasReferences(endpoint)) {
+                            self.enabledEndpointsWithValues.remove(endpoint);
+                        }
                     }
                 });
 
@@ -140,11 +145,13 @@ define([
 
                 if (endpoint.isSingleValued() && workItemReferences.hasReferences(endpoint)) {
                     workItemReferences.remove(endpoint, workItemReferences.getReferences(endpoint).at(0));
-                    self.enabledEndpointsWithValues.remove(endpoint);
                 }
 
                 workItemReferences.add.apply(workItemReferences, [endpoint].concat(references));
-                self.enabledEndpointsWithValues.add(endpoint);
+
+                if (!self.enabledEndpointsWithValues.contains(endpoint)) {
+                    self.enabledEndpointsWithValues.add(endpoint);
+                }
             });
         }
     });

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
@@ -2,6 +2,7 @@ define([
     "dojo/_base/declare",
     "dojo/_base/lang",
     "dojo/dom-construct",
+    "dojo/dom-style",
     "dojo/string",
     "../../services/MainDataStore",
     "dijit/MenuItem",
@@ -16,7 +17,7 @@ define([
     "com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown",
     "com.ibm.team.workitem.web.model.links.WorkItemEndpoints",
     "com.ibm.team.workitem.web.ui.internal.view.editor.presentations.nonattribute.links.LinksDialogLauncher"
-], function (declare, lang, domConstruct, string,
+], function (declare, lang, domConstruct, domStyle, string,
     MainDataStore,
     MenuItem,
     _WidgetBase, _TemplatedMixin,
@@ -73,6 +74,10 @@ define([
             actionsMenu.valueChosen.addListener(lang.hitch(this, function(chosenDescriptor) {
                 this._launchDialog(workingCopy, workItemReferences, chosenDescriptor);
             }));
+
+            domStyle.set(actionsMenu._view._dropdownElement, "float", "none");
+            domStyle.set(actionsMenu._view._dropdownElement, "border-right", "none");
+            domStyle.set(actionsMenu._view._dropdownArrow, "display", "none");
         },
 
         _getEndpointLabel: function(endPoint) {

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
@@ -11,10 +11,14 @@ define([
     "dojo/text!./SetNewWorkItemLinks.html",
     "jazz/css!./SetNewWorkItemLinks.css",
     "com.ibm.jdojox.util.ArrayList",
+    "com.ibm.jdojox.util.JDojoX",
     "com.ibm.team.rtc.foundation.web.model.Bindable",
     "com.ibm.team.rtc.foundation.web.model.BindableList",
+    "com.ibm.team.rtc.foundation.web.model.Label",
+    "com.ibm.team.rtc.foundation.web.model.ListBindings",
     "com.ibm.team.rtc.foundation.web.ui.util.Sprites",
     "com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown",
+    "com.ibm.team.rtc.foundation.web.ui.views.controller.ArtifactMultiList",
     "com.ibm.team.workitem.web.model.links.WorkItemEndpoints",
     "com.ibm.team.workitem.web.ui.internal.view.editor.presentations.nonattribute.links.LinksDialogLauncher"
 ], function (declare, lang, domConstruct, domStyle, string,
@@ -23,10 +27,14 @@ define([
     _WidgetBase, _TemplatedMixin,
     template) {
     var ArrayList = com.ibm.jdojox.util.ArrayList;
+    var JDojoX = com.ibm.jdojox.util.JDojoX;
     var Bindable = com.ibm.team.rtc.foundation.web.model.Bindable;
     var BindableList = com.ibm.team.rtc.foundation.web.model.BindableList;
+    var Label = com.ibm.team.rtc.foundation.web.model.Label;
+    var ListBindings = com.ibm.team.rtc.foundation.web.model.ListBindings;
     var Sprites = com.ibm.team.rtc.foundation.web.ui.util.Sprites;
     var ActionDropdown = com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown;
+    var ArtifactMultiList = com.ibm.team.rtc.foundation.web.ui.views.controller.ArtifactMultiList;
     var WorkItemEndpoints = com.ibm.team.workitem.web.model.links.WorkItemEndpoints;
     var LinksDialogLauncher = com.ibm.team.workitem.web.ui.internal.view.editor.presentations.nonattribute.links.LinksDialogLauncher;
 
@@ -64,35 +72,72 @@ define([
             var actionsMenuDiv = domConstruct.create("div", null, this.linksContainer);
             var actionsMenu = ActionDropdown.create({}, actionsMenuDiv);
 
-            actionsMenu.renderer(lang.hitch(this, function(endPoint) {
+            actionsMenu.renderer(lang.hitch(this, function (endpoint) {
                 return new MenuItem({
-                    label: this._getEndpointLabel(endPoint),
-                    iconClass: Sprites.cssClassName(endPoint.getIcon())
+                    label: this._getEndpointLabel(endpoint),
+                    iconClass: Sprites.cssClassName(endpoint.getIcon())
                 });
             })).values(endpointList).defaultValue(defaultEndpoint).bind();
 
-            actionsMenu.valueChosen.addListener(lang.hitch(this, function(chosenDescriptor) {
+            actionsMenu.valueChosen.addListener(lang.hitch(this, function (chosenDescriptor) {
                 this._launchDialog(workingCopy, workItemReferences, chosenDescriptor);
             }));
 
             domStyle.set(actionsMenu._view._dropdownElement, "float", "none");
             domStyle.set(actionsMenu._view._dropdownElement, "border-right", "none");
             domStyle.set(actionsMenu._view._dropdownArrow, "display", "none");
+
+            // Links pres
+            var listViewDiv = domConstruct.create("div", null, this.linksContainer);
+            var listView = ArtifactMultiList.create(listViewDiv);
+            var endpoints = new BindableList();
+            var headers= new BindableList();
+            var readOnly= new BindableList();
+            var typesMap= new BindableList();
+
+            endpoints.add(parentEndpoint);
+
+            ListBindings.bindWithAdapter(endpoints, headers, function (endpoint) {
+                return new Label(endpoint.getDisplayName()).iconUrl(endpoint.getIcon().toUri());
+            });
+
+            ListBindings.bindWithAdapter(endpoints, readOnly, function (endpoint) {
+                return new Bindable(!endpoint.isUserDeleteable());
+            });
+
+            ListBindings.bindWithAdapter(endpoints, typesMap, function (endpoint) {
+                var result = new BindableList();
+                var references = workItemReferences.getReferences(endpoint);
+
+                ListBindings.bind(references, result);
+
+                result.onListChanged().addListener(function (callbackArg) {
+                    if (!JDojoX.isEqual(result, references) && callbackArg.type === 'remove') {
+                        workItemReferences.remove(endpoint, callbackArg.elements[0]);
+                    }
+                });
+
+                return result;
+            });
+
+            listView.renderer(function (itemReference) {
+                return new Label(itemReference.getComment()).iconUrl(itemReference.getIconUrl()).url(itemReference.getUrl());
+            }).headers(headers).sections(typesMap).readOnly(readOnly).compact(new Bindable(false)).bind();
         },
 
-        _getEndpointLabel: function(endPoint) {
-            return string.substitute(endPoint.isSingleValued() ? "Set ${0}" : "Add ${0}", [endPoint.getDisplayName()]);
+        _getEndpointLabel: function (endpoint) {
+            return string.substitute(endpoint.isSingleValued() ? "Set ${0}" : "Add ${0}", [endpoint.getDisplayName()]);
         },
 
-        _launchDialog: function(workItem, workItemReferences, chosenDescriptor) {
-            LinksDialogLauncher.launchDialog(workItem, chosenDescriptor, function(endPoint) {
+        _launchDialog: function (workItem, workItemReferences, chosenDescriptor) {
+            LinksDialogLauncher.launchDialog(workItem, chosenDescriptor, function (endpoint) {
                 var references = Array.prototype.slice.call(arguments, 1);
 
-                if (endPoint.isSingleValued() && workItemReferences.hasReferences(endPoint)) {
-                    workItemReferences.remove(endPoint, workItemReferences.getReferences(endPoint).at(0));
+                if (endpoint.isSingleValued() && workItemReferences.hasReferences(endpoint)) {
+                    workItemReferences.remove(endpoint, workItemReferences.getReferences(endpoint).at(0));
                 }
 
-                workItemReferences.add.apply(workItemReferences, [endPoint].concat(references));
+                workItemReferences.add.apply(workItemReferences, [endpoint].concat(references));
             });
         }
     });

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
@@ -1,0 +1,37 @@
+define([
+    "dojo/_base/declare",
+    "dojo/_base/lang",
+    "../../services/MainDataStore",
+    "dijit/_WidgetBase",
+    "dijit/_TemplatedMixin",
+    "dojo/text!./SetNewWorkItemLinks.html",
+    "jazz/css!./SetNewWorkItemLinks.css"
+], function (declare, lang,
+    MainDataStore,
+    _WidgetBase, _TemplatedMixin,
+    template) {
+    return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemLinks",
+        [_WidgetBase, _TemplatedMixin,],
+    {
+        templateString: template,
+        mainDataStore: null,
+        hasPresentation: false,
+
+        constructor: function () {
+            this.mainDataStore = MainDataStore.getInstance();
+        },
+
+        // Only create the presentation once the show method is called
+        show: function () {
+            if (!this.hasPresentation) {
+                this.hasPresentation = true;
+                this.createPresentation();
+            }
+        },
+
+        createPresentation: function () {
+            // create the presentation and add it to the view
+            this.linksContainer.innerHTML = "Links Presentation";
+        }
+    });
+});

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
@@ -53,8 +53,6 @@ define([
             this.enabledEndpoints = new ArrayList();
             this.enabledEndpoints.add(WorkItemEndpoints.PARENT_WORK_ITEM);
 
-            this.enabledEndpoints.add(WorkItemEndpoints.DEPENDS_ON_WORK_ITEM);
-
             this.enabledEndpointsWithValues = new BindableList();
         },
 
@@ -90,9 +88,9 @@ define([
                 this._launchDialog(workingCopy, workItemReferences, chosenDescriptor);
             }));
 
-            // domStyle.set(actionsMenu._view._dropdownElement, "float", "none");
-            // domStyle.set(actionsMenu._view._dropdownElement, "border-right", "none");
-            // domStyle.set(actionsMenu._view._dropdownArrow, "display", "none");
+            if (this.enabledEndpoints.size() === 1) {
+                this._hideDropdown(actionsMenu._view);
+            }
 
             // Links pres
             var listViewDiv = domConstruct.create("div", null, this.linksContainer);
@@ -153,6 +151,12 @@ define([
                     self.enabledEndpointsWithValues.add(endpoint);
                 }
             });
+        },
+
+        _hideDropdown: function (actionsMenuView) {
+            domStyle.set(actionsMenuView._dropdownElement, "float", "none");
+            domStyle.set(actionsMenuView._dropdownElement, "border-right", "none");
+            domStyle.set(actionsMenuView._dropdownArrow, "display", "none");
         }
     });
 });

--- a/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
+++ b/resources/ui/widget/components/SetNewWorkItemLinks/SetNewWorkItemLinks.js
@@ -1,17 +1,33 @@
 define([
     "dojo/_base/declare",
+    "dojo/_base/lang",
     "dojo/dom-construct",
+    "dojo/string",
     "../../services/MainDataStore",
+    "dijit/MenuItem",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dojo/text!./SetNewWorkItemLinks.html",
     "jazz/css!./SetNewWorkItemLinks.css",
-    "com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown"
-], function (declare, domConstruct,
+    "com.ibm.jdojox.util.ArrayList",
+    "com.ibm.team.rtc.foundation.web.model.Bindable",
+    "com.ibm.team.rtc.foundation.web.model.BindableList",
+    "com.ibm.team.rtc.foundation.web.ui.util.Sprites",
+    "com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown",
+    "com.ibm.team.workitem.web.model.links.WorkItemEndpoints",
+    "com.ibm.team.workitem.web.ui.internal.view.editor.presentations.nonattribute.links.LinksDialogLauncher"
+], function (declare, lang, domConstruct, string,
     MainDataStore,
+    MenuItem,
     _WidgetBase, _TemplatedMixin,
     template) {
+    var ArrayList = com.ibm.jdojox.util.ArrayList;
+    var Bindable = com.ibm.team.rtc.foundation.web.model.Bindable;
+    var BindableList = com.ibm.team.rtc.foundation.web.model.BindableList;
+    var Sprites = com.ibm.team.rtc.foundation.web.ui.util.Sprites;
     var ActionDropdown = com.ibm.team.rtc.foundation.web.ui.views.controller.ActionDropdown;
+    var WorkItemEndpoints = com.ibm.team.workitem.web.model.links.WorkItemEndpoints;
+    var LinksDialogLauncher = com.ibm.team.workitem.web.ui.internal.view.editor.presentations.nonattribute.links.LinksDialogLauncher;
 
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemLinks",
         [_WidgetBase, _TemplatedMixin,],
@@ -33,8 +49,46 @@ define([
         },
 
         createPresentation: function () {
+            var workingCopy = this.mainDataStore.workItem.getWorkingCopy();
+            var workItemReferences = workingCopy.getWorkItemReferences();
+            var parentEndpoint = WorkItemEndpoints.PARENT_WORK_ITEM;
+            var endpointList = new BindableList();
+            var defaultEndpoint = new Bindable();
+            var endpointArrayList = new ArrayList();
+
+            endpointArrayList.add(parentEndpoint);
+            endpointList.add(endpointArrayList);
+            defaultEndpoint.setValue(parentEndpoint);
+
             var actionsMenuDiv = domConstruct.create("div", null, this.linksContainer);
             var actionsMenu = ActionDropdown.create({}, actionsMenuDiv);
+
+            actionsMenu.renderer(lang.hitch(this, function(endPoint) {
+                return new MenuItem({
+                    label: this._getEndpointLabel(endPoint),
+                    iconClass: Sprites.cssClassName(endPoint.getIcon())
+                });
+            })).values(endpointList).defaultValue(defaultEndpoint).bind();
+
+            actionsMenu.valueChosen.addListener(lang.hitch(this, function(chosenDescriptor) {
+                this._launchDialog(workingCopy, workItemReferences, chosenDescriptor);
+            }));
+        },
+
+        _getEndpointLabel: function(endPoint) {
+            return string.substitute(endPoint.isSingleValued() ? "Set ${0}" : "Add ${0}", [endPoint.getDisplayName()]);
+        },
+
+        _launchDialog: function(workItem, workItemReferences, chosenDescriptor) {
+            LinksDialogLauncher.launchDialog(workItem, chosenDescriptor, function(endPoint) {
+                var references = Array.prototype.slice.call(arguments, 1);
+
+                if (endPoint.isSingleValued() && workItemReferences.hasReferences(endPoint)) {
+                    workItemReferences.remove(endPoint, workItemReferences.getReferences(endPoint).at(0));
+                }
+
+                workItemReferences.add.apply(workItemReferences, [endPoint].concat(references));
+            });
         }
     });
 });

--- a/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.html
+++ b/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.html
@@ -1,4 +1,6 @@
 <div style="display: none;">
     <div data-dojo-attach-point="setNewWorkItemAttributes"
         data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemAttributes"></div>
+    <div data-dojo-attach-point="setNewWorkItemLinks"
+        data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemLinks"></div>
 </div>

--- a/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.html
+++ b/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.html
@@ -1,0 +1,4 @@
+<div style="display: none;">
+    <div data-dojo-attach-point="setNewWorkItemAttributes"
+        data-dojo-type="com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemAttributes"></div>
+</div>

--- a/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.js
+++ b/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.js
@@ -3,6 +3,7 @@ define([
     "dojo/dom-style",
     "../../services/MainDataStore",
     "../SetNewWorkItemAttributes/SetNewWorkItemAttributes",
+    "../SetNewWorkItemLinks/SetNewWorkItemLinks",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
@@ -10,7 +11,7 @@ define([
     "jazz/css!./SetNewWorkItemValues.css"
 ], function (declare, domStyle,
     MainDataStore,
-    SetNewWorkItemAttributes,
+    SetNewWorkItemAttributes, SetNewWorkItemLinks,
     _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemValues",
@@ -41,7 +42,11 @@ define([
             this.mainDataStore.selectedRepositoryData.issuesToLink.watchElements(function () {
                 var hasItems = self.mainDataStore.selectedRepositoryData.issuesToLink.length > 0;
                 self.set("visible", hasItems);
-                self.setNewWorkItemAttributes.show();
+
+                if (hasItems) {
+                    self.setNewWorkItemAttributes.show();
+                    self.setNewWorkItemLinks.show();
+                }
             });
         }
     });

--- a/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.js
+++ b/resources/ui/widget/components/SetNewWorkItemValues/SetNewWorkItemValues.js
@@ -1,0 +1,48 @@
+define([
+    "dojo/_base/declare",
+    "dojo/dom-style",
+    "../../services/MainDataStore",
+    "../SetNewWorkItemAttributes/SetNewWorkItemAttributes",
+    "dijit/_WidgetBase",
+    "dijit/_TemplatedMixin",
+    "dijit/_WidgetsInTemplateMixin",
+    "dojo/text!./SetNewWorkItemValues.html",
+    "jazz/css!./SetNewWorkItemValues.css"
+], function (declare, domStyle,
+    MainDataStore,
+    SetNewWorkItemAttributes,
+    _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
+    template) {
+    return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.setNewWorkItemValues",
+        [_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin],
+    {
+        templateString: template,
+
+        visible: false,
+        _setVisibleAttr: function (visible) {
+            domStyle.set(this.domNode, "display", visible ? "block" : "none");
+            this._set("visible", visible);
+        },
+
+        constructor: function () {
+            this.mainDataStore = MainDataStore.getInstance();
+        },
+
+        startup: function () {
+            if (this.mainDataStore.newWorkItemMode) {
+                this.watchDataStore();
+            }
+        },
+
+        watchDataStore: function () {
+            var self = this;
+
+            // Only show the attributes when the list of selected issues isn't empty
+            this.mainDataStore.selectedRepositoryData.issuesToLink.watchElements(function () {
+                var hasItems = self.mainDataStore.selectedRepositoryData.issuesToLink.length > 0;
+                self.set("visible", hasItems);
+                self.setNewWorkItemAttributes.show();
+            });
+        }
+    });
+});

--- a/resources/ui/widget/services/JazzRestService.js
+++ b/resources/ui/widget/services/JazzRestService.js
@@ -1,12 +1,13 @@
 define([
     "dojo/_base/declare",
     "dojo/_base/array",
+    "dojo/_base/lang",
     "dojo/json",
     "dojo/request/xhr",
     "dojo/Deferred",
     "../components/NewWorkItemList/NewWorkItemList",
     "com.ibm.team.workitem.web.model.links.WorkItemEndpoints"
-], function (declare, array, json, xhr, Deferred, NewWorkItemList) {
+], function (declare, array, lang, json, xhr, Deferred, NewWorkItemList) {
     var WorkItemEndpoints = com.ibm.team.workitem.web.model.links.WorkItemEndpoints;
 
     var _instance = null;
@@ -78,6 +79,10 @@ define([
                 // Copy some values from the work item before it's saved and they are no longer available.
                 // These values will be needed for setting up the other new work items.
                 currentWorkItemValues = this.getWorkItemValuesFromOriginalWorkItem(currentWorkItem);
+
+                // Keep a copy of the values from the first work item so that they are not changed
+                // when adding the values from the git issue
+                currentWorkItemValues = lang.clone(currentWorkItemValues);
 
                 // Setup the new work item
                 this.setupNewWorkItem(currentWorkItem, gitIssues[0], progressOptions, addBackLinksFunction);
@@ -173,6 +178,11 @@ define([
         // and the values of the links show in the view from the first work item
         setWorkItemValuesFromOriginalWorkItemValues: function (newWorkItem, originalWorkItemValues) {
             var self = this;
+
+            // Create a copy of the values before copying to the new work items. Otherwise,
+            // the objects would still be linked and changing the value in one work item might
+            // change it in the other one
+            originalWorkItemValues = lang.clone(originalWorkItemValues);
 
             this.attributesToShow.forEach(function (attributeId) {
                 self.copyWorkItemAttributeValue(attributeId, originalWorkItemValues.attributeValues[attributeId], newWorkItem);


### PR DESCRIPTION
This adds the option for the user to set the parent work item (link) for all the new work items when creating work items from git issues.

If this option is used, all the new work items will become children of the chosen parent work item.