### PR TITLE
Indicate duplicates using tags

### DIFF
--- a/resources/ui/widget/components/ListItem/ListItem.css
+++ b/resources/ui/widget/components/ListItem/ListItem.css
@@ -6,6 +6,10 @@
     transition: all 0.3s ease-out;
 }
 
+.rtcGitConnectorViewAndSelectListItem.duplicate {
+    background-color: #fbbab7;
+}
+
 .rtcGitConnectorViewAndSelectListItem:hover {
     background-color: #cacaca;
 }

--- a/resources/ui/widget/components/ListItem/ListItem.css
+++ b/resources/ui/widget/components/ListItem/ListItem.css
@@ -77,5 +77,6 @@
 
 .rtcGitConnectorViewAndSelectListItem .rtcGitConnectorViewAndSelectListItemButton.exclamationTriangle {
     color: darkorange;
+    cursor: help;
     transform: none;
 }

--- a/resources/ui/widget/components/ListItem/ListItem.css
+++ b/resources/ui/widget/components/ListItem/ListItem.css
@@ -6,10 +6,6 @@
     transition: all 0.3s ease-out;
 }
 
-.rtcGitConnectorViewAndSelectListItem.duplicate {
-    background-color: #fbbab7;
-}
-
 .rtcGitConnectorViewAndSelectListItem:hover {
     background-color: #cacaca;
 }
@@ -76,5 +72,10 @@
 .rtcGitConnectorViewAndSelectListItem.checkButton .rtcGitConnectorViewAndSelectListItemButton {
     color: #555;
     cursor: default;
+    transform: none;
+}
+
+.rtcGitConnectorViewAndSelectListItem .rtcGitConnectorViewAndSelectListItemButton.exclamationTriangle {
+    color: darkorange;
     transform: none;
 }

--- a/resources/ui/widget/components/ListItem/ListItem.html
+++ b/resources/ui/widget/components/ListItem/ListItem.html
@@ -1,6 +1,6 @@
-<div class="rtcGitConnectorViewAndSelectListItem" data-dojo-attach-point="listItem">
-    <div class="rtcGitConnectorViewAndSelectListItemButton" data-dojo-attach-point="itemButton" data-dojo-attach-event="onclick:_onButtonClick"></div>
-    <div class="rtcGitConnectorViewAndSelectListItemContent" data-dojo-attach-point="itemContent" data-dojo-attach-event="onclick:_onContentClick">
+<div data-dojo-attach-point="listItem">
+    <div class="${baseClass}Button" data-dojo-attach-point="itemButton" data-dojo-attach-event="onclick:_onButtonClick"></div>
+    <div class="${baseClass}Content" data-dojo-attach-point="itemContent" data-dojo-attach-event="onclick:_onContentClick">
         <span class="rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine" data-dojo-attach-point="firstLine"></span>
         <span class="rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine" data-dojo-attach-point="secondLine"></span>
     </div>

--- a/resources/ui/widget/components/ListItem/ListItem.html
+++ b/resources/ui/widget/components/ListItem/ListItem.html
@@ -4,4 +4,5 @@
         <span class="rtcGitConnectorSelectListSpan rtcGitConnectorSelectListFirstLine" data-dojo-attach-point="firstLine"></span>
         <span class="rtcGitConnectorSelectListSpan rtcGitConnectorSelectListSecondLine" data-dojo-attach-point="secondLine"></span>
     </div>
+    <div class="${baseClass}Button exclamationTriangle" data-dojo-attach-point="itemRightButton"></div>
 </div>

--- a/resources/ui/widget/components/ListItem/ListItem.js
+++ b/resources/ui/widget/components/ListItem/ListItem.js
@@ -12,6 +12,7 @@ define([
         [_WidgetBase, _TemplatedMixin,],
     {
         templateString: template,
+        baseClass: "rtcGitConnectorViewAndSelectListItem",
 
         itemId: "",
         _setItemIdAttr: { node: "listItem", type: "attribute", attribute: "data-item-id" },

--- a/resources/ui/widget/components/ListItem/ListItem.js
+++ b/resources/ui/widget/components/ListItem/ListItem.js
@@ -28,7 +28,7 @@ define([
             domClass.remove(this.listItem, this.buttonType + "Button");
             domClass.add(this.listItem, buttonName + "Button");
             this.itemButton.innerHTML = com_siemens_bt_jazz_rtcgitconnector_modules
-                .FontAwesome.icon({ prefix: 'fas', iconName: buttonName }).html[0];
+                .FontAwesome.icon({ prefix: "fas", iconName: buttonName }).html[0];
             this._set("buttonType", buttonName);
         },
 
@@ -55,14 +55,15 @@ define([
         },
 
         duplicate: false,
-        _setDuplicateAttr: function (duplicateText) {
-            if (duplicateText) {
-                domClass.add(this.listItem, "duplicate");
+        _setDuplicateAttr: function (duplicate) {
+            if (duplicate) {
+                this.itemRightButton.innerHTML = com_siemens_bt_jazz_rtcgitconnector_modules
+                    .FontAwesome.icon({ prefix: "fas", iconName: "exclamation-triangle" }).html[0];
             } else {
-                domClass.remove(this.listItem, "duplicate");
+                this.itemRightButton.innerHtml = "";
             }
 
-            this._set("duplicate", !!duplicateText);
+            this._set("duplicate", duplicate);
         },
 
         _onButtonClick: function (e) {

--- a/resources/ui/widget/components/ListItem/ListItem.js
+++ b/resources/ui/widget/components/ListItem/ListItem.js
@@ -1,11 +1,12 @@
 define([
     "dojo/_base/declare",
     "dojo/dom-class",
+    "dojo/dom-style",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dojo/text!./ListItem.html",
     "jazz/css!./ListItem.css"
-], function (declare, domClass,
+], function (declare, domClass, domStyle,
     _WidgetBase, _TemplatedMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.listItem",
@@ -59,8 +60,10 @@ define([
             if (duplicate) {
                 this.itemRightButton.innerHTML = com_siemens_bt_jazz_rtcgitconnector_modules
                     .FontAwesome.icon({ prefix: "fas", iconName: "exclamation-triangle" }).html[0];
+                domStyle.set(this.itemRightButton, "display", "block");
             } else {
                 this.itemRightButton.innerHtml = "";
+                domStyle.set(this.itemRightButton, "display", "none");
             }
 
             this._set("duplicate", duplicate);

--- a/resources/ui/widget/components/ListItem/ListItem.js
+++ b/resources/ui/widget/components/ListItem/ListItem.js
@@ -54,6 +54,17 @@ define([
             this._set("notClickable", notClickable);
         },
 
+        duplicate: false,
+        _setDuplicateAttr: function (duplicateText) {
+            if (duplicateText) {
+                domClass.add(this.listItem, "duplicate");
+            } else {
+                domClass.remove(this.listItem, "duplicate");
+            }
+
+            this._set("duplicate", !!duplicateText);
+        },
+
         _onButtonClick: function (e) {
             this.onButtonClick(this.itemId);
         },

--- a/resources/ui/widget/components/MainLayout/MainLayout.js
+++ b/resources/ui/widget/components/MainLayout/MainLayout.js
@@ -197,6 +197,9 @@ define([
                             // Get the new issue and add it to the list of issues to link
                             self.mainDataStore.selectedRepositoryData.issuesToLink.push(result);
 
+                            // Add a tag to the work item so that it's clear that it's been created as a git issue
+                            self.jazzRestService.addTagsToWorkItem(self.mainDataStore.workItem, "created-as-git-issue");
+
                             // Continue with the normal saving.
                             saveTheLinks();
                         }, function (error) {

--- a/resources/ui/widget/components/MainLayout/MainLayout.js
+++ b/resources/ui/widget/components/MainLayout/MainLayout.js
@@ -198,7 +198,7 @@ define([
                             self.mainDataStore.selectedRepositoryData.issuesToLink.push(result);
 
                             // Add a tag to the work item so that it's clear that it's been created as a git issue
-                            self.jazzRestService.addTagsToWorkItem(self.mainDataStore.workItem, "created-as-git-issue");
+                            self.jazzRestService.addCreatedGitIssueTagToWorkItem(self.mainDataStore.workItem);
 
                             // Continue with the normal saving.
                             saveTheLinks();

--- a/resources/ui/widget/components/MainLayout/MainLayout.js
+++ b/resources/ui/widget/components/MainLayout/MainLayout.js
@@ -427,7 +427,10 @@ define([
                             requestsToLink: []
                         };
 
-                        self.gitRestService.addBackLinksToGitHost(addBackLinksToGitHostParams)
+                        self.gitRestService.addBackLinksToGitHost(addBackLinksToGitHostParams).then(function (result) {
+                            // Add a label to the git issue to indicate that it's been created as a work item in RTC
+                            self.gitRestService.addCreatedWorkItemLabelToIssue(selectedRepository, gitHost, accessToken, gitIssue);
+                        });
                     }
                 );
             } else {

--- a/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
+++ b/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
@@ -192,8 +192,17 @@ define([
 
                 var details;
                 var buttonType;
+                var duplicate = false;
 
                 if (issue.originalId < 0) {
+                    var workItemTags = self.mainDataStore.workItem.getValue({
+                        path: ["attributes", "internalTags", "content"]
+                    });
+
+                    if (workItemTags.length && workItemTags.indexOf("created-as-git-issue") !== -1) {
+                        duplicate = true;
+                    }
+
                     details = "This will create a new issue in " + gitHost.displayName + " using the information from the current work item";
                     buttonType = "plus";
                 } else {
@@ -210,6 +219,7 @@ define([
                 listItem.set("title", issue.title);
                 listItem.set("details", details);
                 listItem.set("buttonType", buttonType);
+                listItem.set("duplicate", duplicate);
 
                 listItem.onButtonClick = lang.hitch(self, self.listItemButtonClick);
                 listItem.onContentClick = lang.hitch(self, self.setSelectedItemById);

--- a/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
+++ b/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
@@ -12,13 +12,14 @@ define([
     "../../js/ViewHelper",
     "../DetailsPane/DetailsPane",
     "../ListItem/ListItem",
+    "dijit/Tooltip",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "dijit/_WidgetsInTemplateMixin",
     "dojo/text!./ViewAndSelectIssues.html"
 ], function (declare, array, lang, dom, domConstruct, on, json,
     MainDataStore, JazzRestService, GitRestService, ViewHelper, DetailsPane, ListItem,
-    _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
+    Tooltip, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
     template) {
     return declare("com.siemens.bt.jazz.workitemeditor.rtcGitConnector.ui.widget.viewAndSelectIssues",
         [_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin],
@@ -28,6 +29,7 @@ define([
         jazzRestService: null,
         gitRestService: null,
         viewIssues: null,
+        tooltip: null,
 
         constructor: function () {
             this.mainDataStore = MainDataStore.getInstance();
@@ -184,6 +186,16 @@ define([
             var gitHost = self.mainDataStore.selectedRepositorySettings.get("gitHost");
             domConstruct.empty(this.listItemsContainer);
 
+            if (self.tooltip) {
+                self.tooltip.destroy();
+                self.tooltip = null;
+            }
+
+            self.tooltip = new Tooltip({
+                position: ["above", "below"],
+                showDelay: 0
+            });
+
             array.forEach(this.viewIssues, function (issue) {
                 // Don't add the create a new issue row when in new work item mode
                 if (issue.originalId < 0 && self.mainDataStore.newWorkItemMode) {
@@ -201,6 +213,7 @@ define([
 
                     if (workItemTags.length && workItemTags.indexOf("created-as-git-issue") !== -1) {
                         duplicate = true;
+                        self.tooltip.set("label", "This work item has already been created as a git issue.");
                     }
 
                     details = "This will create a new issue in " + gitHost.displayName + " using the information from the current work item";
@@ -216,6 +229,7 @@ define([
 
                     if (self.mainDataStore.newWorkItemMode && issue.labels && issue.labels.indexOf("created-as-rtc-work-item") !== -1) {
                         duplicate = true;
+                        self.tooltip.set("label", "This git issue has already been created as a work item.");
                     }
                 }
 
@@ -230,6 +244,10 @@ define([
 
                 issue.listItem = listItem;
                 domConstruct.place(listItem.domNode, self.listItemsContainer);
+
+                if (duplicate) {
+                    self.tooltip.addTarget(listItem.itemRightButton);
+                }
             });
         },
 

--- a/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
+++ b/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
@@ -213,6 +213,10 @@ define([
                     } else {
                         buttonType = "link";
                     }
+
+                    if (self.mainDataStore.newWorkItemMode && issue.labels && issue.labels.indexOf("created-as-rtc-work-item") !== -1) {
+                        duplicate = true;
+                    }
                 }
 
                 var listItem = new ListItem(issue.originalId);

--- a/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
+++ b/resources/ui/widget/components/ViewAndSelectIssues/ViewAndSelectIssues.js
@@ -219,17 +219,17 @@ define([
                     details = "This will create a new issue in " + gitHost.displayName + " using the information from the current work item";
                     buttonType = "plus";
                 } else {
+                    if (self.mainDataStore.newWorkItemMode && issue.labels && issue.labels.indexOf("created-as-rtc-work-item") !== -1) {
+                        duplicate = true;
+                        self.tooltip.set("label", "This git issue has already been created as a work item.");
+                    }
+
                     details = ViewHelper.GetIssueOrRequestDateString(issue);
 
                     if (issue.alreadyLinked) {
                         buttonType = "check";
                     } else {
                         buttonType = "link";
-                    }
-
-                    if (self.mainDataStore.newWorkItemMode && issue.labels && issue.labels.indexOf("created-as-rtc-work-item") !== -1) {
-                        duplicate = true;
-                        self.tooltip.set("label", "This git issue has already been created as a work item.");
                     }
                 }
 

--- a/resources/ui/widget/services/GitRestService.js
+++ b/resources/ui/widget/services/GitRestService.js
@@ -59,9 +59,7 @@ define([
             } else if (gitHost.name === this.gitLabString) {
                 return this.createNewGitLabIssue(selectedGitRepository, accessToken, workItem);
             } else {
-                var deferred = new Deferred();
-                deferred.reject("Invalid git host.");
-                return deferred.promise;
+                return this._createInvalidHostPromise();
             }
         },
 
@@ -419,9 +417,7 @@ define([
             } else if (gitHost.name === this.gitLabString) {
                 return this.getGitLabCommitById(selectedGitRepository, accessToken, commitSha, alreadyLinkedUrls);
             } else {
-                var deferred = new Deferred();
-                deferred.reject("Invalid git host.");
-                return deferred.promise;
+                return this._createInvalidHostPromise();
             }
         },
 
@@ -490,9 +486,7 @@ define([
             } else if (gitHost.name === this.gitLabString) {
                 return this.getGitLabIssueById(selectedGitRepository, accessToken, issueId, alreadyLinkedUrls);
             } else {
-                var deferred = new Deferred();
-                deferred.reject("Invalid git host.");
-                return deferred.promise;
+                return this._createInvalidHostPromise();
             }
         },
 
@@ -563,9 +557,7 @@ define([
             } else if (gitHost.name === this.gitLabString) {
                 return this.getGitLabRequestById(selectedGitRepository, accessToken, requestId, alreadyLinkedUrls);
             } else {
-                var deferred = new Deferred();
-                deferred.reject("Invalid git host.");
-                return deferred.promise;
+                return this._createInvalidHostPromise();
             }
         },
 
@@ -632,9 +624,7 @@ define([
             } else if (gitHost.name === this.gitLabString) {
                 return this.getRecentGitLabCommits(selectedGitRepository, accessToken, alreadyLinkedUrls);
             } else {
-                var deferred = new Deferred();
-                deferred.reject("Invalid git host.");
-                return deferred.promise;
+                return this._createInvalidHostPromise();
             }
         },
 
@@ -729,9 +719,7 @@ define([
             } else if (gitHost.name === this.gitLabString) {
                 return this.getRecentGitLabIssues(selectedGitRepository, accessToken, alreadyLinkedUrls);
             } else {
-                var deferred = new Deferred();
-                deferred.reject("Invalid git host.");
-                return deferred.promise;
+                return this._createInvalidHostPromise();
             }
         },
 
@@ -825,9 +813,7 @@ define([
             } else if (gitHost.name === this.gitLabString) {
                 return this.getRecentGitLabRequests(selectedGitRepository, accessToken, alreadyLinkedUrls);
             } else {
-                var deferred = new Deferred();
-                deferred.reject("Invalid git host.");
-                return deferred.promise;
+                return this._createInvalidHostPromise();
             }
         },
 
@@ -976,6 +962,12 @@ define([
                 deferred.reject("Invalid git host.");
             }
 
+            return deferred.promise;
+        },
+
+        _createInvalidHostPromise: function () {
+            var deferred = new Deferred();
+            deferred.reject("Invalid git host.");
             return deferred.promise;
         },
 

--- a/resources/ui/widget/services/GitRestService.js
+++ b/resources/ui/widget/services/GitRestService.js
@@ -203,7 +203,9 @@ define([
         },
 
         getTagsFromWorkItem: function (workItem, asArray) {
-            var tags = workItem.object.attributes.internalTags.content;
+            var tags = workItem.getValue({
+                path: ["attributes", "internalTags", "content"]
+            });
             tags = (tags.length) ? tags + ", " : tags;
             tags += "from-rtc-work-item";
 

--- a/resources/ui/widget/services/JazzRestService.js
+++ b/resources/ui/widget/services/JazzRestService.js
@@ -56,6 +56,12 @@ define([
             this._createLinkTypeContainerGetters();
         },
 
+        // Add a tag to the work item to indicate that it's been created as a git issue.
+        // This only sets the value in the object and doesn't save the work item.
+        addCreatedGitIssueTagToWorkItem: function (workItem) {
+            this.addTagsToWorkItem(workItem, "created-as-git-issue");
+        },
+
         // Adds the specified tags to the work item object. Doesn't save the work item!
         // Pass in the tags as a string of comma separated values.
         addTagsToWorkItem: function (workItem, tags) {

--- a/resources/ui/widget/services/JazzRestService.js
+++ b/resources/ui/widget/services/JazzRestService.js
@@ -56,6 +56,29 @@ define([
             this._createLinkTypeContainerGetters();
         },
 
+        // Adds the specified tags to the work item object. Doesn't save the work item!
+        // Pass in the tags as a string of comma separated values.
+        addTagsToWorkItem: function (workItem, tags) {
+            // Get the tags value. It might have been set by the user.
+            var tagsValue = workItem.getValue({
+                path: ["attributes", "internalTags", "content"]
+            });
+
+            // Add a custom tags to the new work item
+            if (tagsValue) {
+                tagsValue += ", " + tags;
+            } else {
+                tagsValue = tags;
+            }
+
+            // Set the tags in the work item object
+            workItem.setValue({
+                path: ["attributes", "internalTags", "content"],
+                attributeId: "internalTags",
+                value: tagsValue
+            });
+        },
+
         // Create and fill work items from the git issues.
         createNewWorkItems: function (currentWorkItem, gitIssues, finishedLoadingFunction, addBackLinksFunction) {
             var self = this;
@@ -321,30 +344,16 @@ define([
                 });
             }
 
-            // Get the tags value. It might have been set by the user.
-            var tagsValue = workItem.getValue({
-                path: ["attributes", "internalTags", "content"]
-            });
-            var fromGitIssueTag = "from-git-issue";
-
             // Add a custom tag to the new work item
-            if (tagsValue) {
-                tagsValue += ", " + fromGitIssueTag;
-            } else {
-                tagsValue = fromGitIssueTag;
-            }
+            var tagsToAdd = "from-git-issue";
 
             // Add any git issue labels as tags
             if (gitIssue.labels) {
-                tagsValue += ", " + gitIssue.labels;
+                tagsToAdd += ", " + gitIssue.labels;
             }
 
-            // Set the git issue labels as tags
-            workItem.setValue({
-                path: ["attributes", "internalTags", "content"],
-                attributeId: "internalTags",
-                value: tagsValue
-            });
+            // Add the custom tag + any git issue labels to the work item
+            this.addTagsToWorkItem(workItem, tagsToAdd);
 
             // Add the git issue as a link
             this.addIssueLinksToWorkItemObject(workItem, [gitIssue]);

--- a/src/RtcGitConnectorModules.js
+++ b/src/RtcGitConnectorModules.js
@@ -59,12 +59,13 @@ export const GitLabApi = require('gitlab/dist/es5').default;
 // Fontawesome fonts
 export const FontAwesome = require('@fortawesome/fontawesome');
 const FaCheck = require('@fortawesome/fontawesome-free-solid/faCheck');
-const FaPlus = require('@fortawesome/fontawesome-free-solid/faPlus');
-const FaMinus = require('@fortawesome/fontawesome-free-solid/faMinus');
-const FaTimes = require('@fortawesome/fontawesome-free-solid/faTimes');
+const FaExclamationTriangle = require('@fortawesome/fontawesome-free-solid/faExclamationTriangle');
 const FaLink = require('@fortawesome/fontawesome-free-solid/faLink');
-const FaTrash = require('@fortawesome/fontawesome-free-solid/faTrash');
+const FaMinus = require('@fortawesome/fontawesome-free-solid/faMinus');
+const FaPlus = require('@fortawesome/fontawesome-free-solid/faPlus');
 const FaSpinner = require('@fortawesome/fontawesome-free-solid/faSpinner');
+const FaTimes = require('@fortawesome/fontawesome-free-solid/faTimes');
+const FaTrash = require('@fortawesome/fontawesome-free-solid/faTrash');
 
 // Build version
 export const buildVersion = '__BUILD_VERSION__';
@@ -72,9 +73,10 @@ export const buildVersion = '__BUILD_VERSION__';
 // Adding the entire solid library doesn't seem to work in the frontend.
 // So we have no other choice than adding them one by one.
 FontAwesome.library.add(FaCheck);
-FontAwesome.library.add(FaPlus);
-FontAwesome.library.add(FaMinus);
-FontAwesome.library.add(FaTimes);
+FontAwesome.library.add(FaExclamationTriangle);
 FontAwesome.library.add(FaLink);
-FontAwesome.library.add(FaTrash);
+FontAwesome.library.add(FaMinus);
+FontAwesome.library.add(FaPlus);
 FontAwesome.library.add(FaSpinner);
+FontAwesome.library.add(FaTimes);
+FontAwesome.library.add(FaTrash);


### PR DESCRIPTION
**Add Tags/Labels**
When creating an issue from a work item, the issue gets the label "from-rtc-work-item". New: The work item also gets a tag "created-as-git-issue". (Only added if it doesn't already exist.)

When creating a work item from a git issue, the work item gets the tag "from-git-issue". New: The git issue also gets a tag "created-as-rtc-work-item". (Only added if it doesn't already exist.)

**Use new Tags/Labels**
When in normal mode: Show a hint next to the "create as git issue" button. Show that the work item has already been created as a git issue (check the tag on the work item "created-as-git-issue"). Don't block the user from creating another one (might be a different git repository).

When in "create work items from git issues" mode: Show a hint next to all git issues that have already been created as work items (check the label on the git issue "created-as-rtc-work-item"). Don't block the user from selecting them anyways.

**Hinting**
A triangle warning icon is shown on the right. Hovering over the icon shows a tooltip with the explanation.